### PR TITLE
Adding unique key and at_key table

### DIFF
--- a/db/migrations/V1__Initial_schema.sql
+++ b/db/migrations/V1__Initial_schema.sql
@@ -1,50 +1,53 @@
 CREATE TABLE users (
   id          serial primary key,
   fullname    text,
-  username    text,
+  username    text unique,
   email       text
 );
 
 CREATE TABLE role (
   id          serial primary key,
-  name        text
+  name        text unique
 );
 
 CREATE TABLE user_to_role (
   id          serial primary key,
   user_id     int not null references users(id),
-  role_id     int not null references role(id)
+  role_id     int not null references role(id),
+  unique (user_id, role_id)
 );
 
 CREATE TABLE at (
   id          serial primary key,
-  key         text,
-  name        text
+  name        text unique
 );
 
 CREATE TABLE user_to_at (
   id          serial primary key,
   at_id       int not null references at(id),
-  user_id     int not null references users(id)
+  user_id     int not null references users(id),
+  unique (at_id, user_id)
 );
 
 CREATE TABLE at_version (
   id               serial primary key,
   at_id            int not null references at(id),
   version          varchar(256),
-  release_order    int
+  release_order    int,
+  unique (at_id, version)
 );
 
 CREATE TABLE browser (
   id          serial primary key,
-  name        text
+  name        text unique
 );
 
 CREATE TABLE browser_version (
   id               serial primary key,
   browser_id       int not null references browser(id),
   version          varchar(256),
-  release_order    int
+  release_order    int,
+  unique (browser_id, version)
 );
 
 CREATE TABLE test_version (
@@ -52,13 +55,20 @@ CREATE TABLE test_version (
   git_repo    text,
   git_tag     text,
   git_hash    text,
-  datetime    timestamp
+  datetime    timestamp with time zone
+);
+
+CREATE TABLE at_key (
+  id              serial primary key,
+  key             text,
+  at_id           int not null references at(id),
+  test_version_id int not null references test_version(id)
 );
 
 CREATE TABLE apg_example (
-  id          serial primary key,
-  directory   text,
-  name        text,
+  id              serial primary key,
+  directory       text,
+  name            text,
   test_version_id int not null references test_version(id)
 );
 


### PR DESCRIPTION
Three changes:
- Adding unique keys
- Adding timezone to datatime in the test_version. idk if this is the right thing to do for sure, I'm having trouble thinking about whether we need this field.
- Adding a table for "at_key" because I realized that at any new PR to the tests, the list of ATs you can test may change. This table tells us which ATs the tests at a certain test version support and this information is directly imported from the test repository.

To test/get new db:
```
flyway clean -user=$PGUSER -password=$PGPASSWORD -url=jdbc:postgresql://$PGHOST:$PGPORT/$PGDATABASE -locations=filesystem:$(pwd)/db/migrations -baselineVersion=0 -baselineOnMigrate=true

yarn db-migrate:dev
```