### PR TITLE
Changes based on expected test refactor and test cycles

### DIFF
--- a/db/migrations/V1__Initial_schema.sql
+++ b/db/migrations/V1__Initial_schema.sql
@@ -17,24 +17,24 @@ CREATE TABLE user_to_role (
   unique (user_id, role_id)
 );
 
-CREATE TABLE at (
+CREATE TABLE at_name (
   id          serial primary key,
   name        text unique
 );
 
 CREATE TABLE user_to_at (
   id          serial primary key,
-  at_id       int not null references at(id),
+  at_name_id  int not null references at_name(id),
   user_id     int not null references users(id),
-  unique (at_id, user_id)
+  unique (at_name_id, user_id)
 );
 
 CREATE TABLE at_version (
   id               serial primary key,
-  at_id            int not null references at(id),
+  at_name_id       int not null references at_name(id),
   version          varchar(256),
   release_order    int,
-  unique (at_id, version)
+  unique (at_name_id, version)
 );
 
 CREATE TABLE browser (
@@ -51,17 +51,18 @@ CREATE TABLE browser_version (
 );
 
 CREATE TABLE test_version (
-  id          serial primary key,
-  git_repo    text,
-  git_tag     text,
-  git_hash    text,
-  datetime    timestamp with time zone
+  id             serial primary key,
+  git_repo       text,
+  git_tag        text,
+  git_hash       text,
+  git_commit_msg text,
+  datetime       timestamp with time zone
 );
 
-CREATE TABLE at_key (
+CREATE TABLE at (
   id              serial primary key,
   key             text,
-  at_id           int not null references at(id),
+  at_name_id      int not null references at_name(id),
   test_version_id int not null references test_version(id)
 );
 
@@ -76,34 +77,36 @@ CREATE TABLE test (
   id              serial primary key,
   name            text,
   file            text,
+  execution_order int,
   apg_example_id  int not null references apg_example(id),
   test_version_id int not null references test_version(id)
 );
 
-CREATE TABLE round (
+CREATE TABLE test_to_at (
   id              serial primary key,
+  test_id         int not null references test(id),
+  at_id           int not null references at(id)
+);
+
+CREATE TABLE test_cycle (
+  id              serial primary key,
+  name            text,
   test_version_id int not null references test_version(id),
   created_user_id int not null references users(id),
   date            date
 );
 
-CREATE TABLE tester_to_round (
-  id              serial primary key,
-  round_id        int not null references round(id),
-  user_id         int not null references users(id)
-);
-
 CREATE TABLE run (
   id                 serial primary key,
-  round_id           int not null references round(id),
+  test_cycle_id      int not null references test_cycle(id),
   at_version_id      int not null references at_version(id),
+  at_id              int not null references at(id),
   browser_version_id int not null references browser_version(id),
   apg_example_id     int not null references apg_example(id)
 );
 
-CREATE TABLE test_to_run (
-  id                 serial primary key,
-  run_id             int not null references run(id),
-  test_id            int not null references test(id),
-  execution_order    int
+CREATE TABLE tester_to_run (
+  id              serial primary key,
+  run_id          int not null references run(id),
+  user_id         int not null references users(id)
 );

--- a/db/migrations/V2__Populate_data.sql
+++ b/db/migrations/V2__Populate_data.sql
@@ -1,0 +1,8 @@
+INSERT INTO role (name) VALUES
+    ('admin'),
+    ('tester');
+
+INSERT INTO browser (name) VALUES
+    ('Firefox'),
+    ('Chrome'),
+    ('Safari');

--- a/db/migrations/V2__Populate_roles.sql
+++ b/db/migrations/V2__Populate_roles.sql
@@ -1,4 +1,0 @@
-INSERT INTO role (name) VALUES
-    ('admin'),
-    ('tester');
-    


### PR DESCRIPTION
This PR has a couple of different changes in one go:
- I realized that need need to get the "applies to" list for each test early on. So there is now a many to many table `test_to_at` which will have an entry for every every AT that a test can be preformed with
- I change the `at` table to `at_name` and the `at_key` table to `at`. The reason why is that the AT VERSIONS (application concept) are related to only the NAME of the at (aria-at test suite concept).  We need to have a table that lists all the `at` concepts for each version of the test suite, as that list is directly imported from the test suite. But the versions are aria-at test suite `at` agnostic and should be carried between `at` concepts if the `at name` is the same for two different aria-at imports. 
- Changed the name of "round" to "test cycle", in following with the new community group terminology
- Changes the "tester_to_round" table to "test_to_run" table according to Isaac's mock ups and CG consensus that tests will just be assigned firstly to runs (never rounds).