### PR TITLE
Results and test queue backend

### DIFF
--- a/db/migrations/V4__Add_view_for_runs.sql
+++ b/db/migrations/V4__Add_view_for_runs.sql
@@ -4,11 +4,15 @@ SELECT
   run.test_cycle_id AS test_cycle_id,
   browser_version.version AS browser_version,
   browser.name AS browser_name,
+  browser.id AS browser_id,
   at.key AS at_key,
+  at.id AS at_id,
   at_name.name AS at_name,
+  at_name.id AS at_name_id,
   at_version.version AS at_version,
   apg_example.directory AS apg_example_directory,
-  apg_example.name AS apg_example_name
+  apg_example.name AS apg_example_name,
+  apg_example.id AS apg_example_id
 FROM
   run,
   browser_version,

--- a/db/migrations/V5__Test_results.sql
+++ b/db/migrations/V5__Test_results.sql
@@ -1,9 +1,9 @@
-CREATE TABLE status (
+CREATE TABLE test_status (
   id              serial primary key,
   name            text
 );
 
-INSERT INTO status (name) VALUES
+INSERT INTO test_status (name) VALUES
     ('skipped'),
     ('incomplete'),
     ('complete');
@@ -13,6 +13,7 @@ CREATE TABLE test_result (
   test_id         int not null references test(id),
   run_id          int not null references run(id),
   user_id         int not null references users(id),
-  status_id       int references test_result_status(id),
+  status_id       int references test_status(id),
   result          json
 );
+

--- a/db/migrations/V5__Test_results.sql
+++ b/db/migrations/V5__Test_results.sql
@@ -1,0 +1,18 @@
+CREATE TABLE status (
+  id              serial primary key,
+  name            text
+);
+
+INSERT INTO status (name) VALUES
+    ('skipped'),
+    ('incomplete'),
+    ('complete');
+
+CREATE TABLE test_result (
+  id              serial primary key,
+  test_id         int not null references test(id),
+  run_id          int not null references run(id),
+  user_id         int not null references users(id),
+  status_id       int references test_result_status(id),
+  result          json
+);

--- a/server/controllers/CycleController.js
+++ b/server/controllers/CycleController.js
@@ -51,7 +51,10 @@ async function getRunsForCycleAndUser(req, res) {
     try {
         const cycleId = req.body.cycle_id;
         const userId = req.body.user_id;
-        let runsById = await CycleService.getRunsForCycleAndUser(cycleId, userId);
+        let runsById = await CycleService.getRunsForCycleAndUser(
+            cycleId,
+            userId
+        );
         res.status(201).json({ runsById });
     } catch (error) {
         res.status(400);

--- a/server/controllers/CycleController.js
+++ b/server/controllers/CycleController.js
@@ -35,6 +35,31 @@ async function deleteCycle(req, res) {
     }
 }
 
+async function saveTestResults(req, res) {
+    try {
+        const testResult = req.body;
+        const savedTestResult = await CycleService.saveTestResults(testResult);
+        res.status(201).json(savedTestResult);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in CycleController: ${error}`);
+    }
+}
+
+async function getRunsForCycleAndUser(req, res) {
+    try {
+        const cycleId = req.body.cycle_id;
+        const userId = req.body.user_id;
+        let runsById = await CycleService.getRunsForCycleAndUser(cycleId, userId);
+        res.status(201).json({ runsById });
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in CycleController: ${error}`);
+    }
+}
+
 async function getAllTestVersions(req, res) {
     try {
         const testVersions = await CycleService.getAllTestVersions();
@@ -50,5 +75,7 @@ module.exports = {
     configureCycle,
     getAllCycles,
     deleteCycle,
+    saveTestResults,
+    getRunsForCycleAndUser,
     getAllTestVersions
 };

--- a/server/routes/cycle.js
+++ b/server/routes/cycle.js
@@ -10,6 +10,12 @@ router.delete('/', CycleController.deleteCycle);
 // Gets all cycles
 router.get('/', CycleController.getAllCycles);
 
+// Save result
+router.post('/result', CycleController.saveTestResults);
+
+// Gets all runs for a given cycle and user
+router.get('/runs', CycleController.getRunsForCycleAndUser);
+
 // Gets test version information necessary to initiate cycle
 router.get('/testversions', CycleController.getAllTestVersions);
 

--- a/server/services/CycleService.js
+++ b/server/services/CycleService.js
@@ -310,7 +310,6 @@ async function getAllTestVersions() {
     }
 }
 
-
 /**
  * Saves a test result and marks the test as "complete"
  *
@@ -344,7 +343,9 @@ async function saveTestResults(testResult) {
              INSERT INTO
                test_result(test_id, run_id, user_id, status_id, result)
              VALUES
-               (${testResult.test_id}, ${testResult.run_id}, ${testResult.user_id}, ${statusId}, ${testResult.result ? testResult.result : "NULL"})
+               (${testResult.test_id}, ${testResult.run_id}, ${
+                testResult.user_id
+            }, ${statusId}, ${testResult.result ? testResult.result : 'NULL'})
              RETURNING ID
         `)
         )[0];
@@ -387,7 +388,6 @@ async function saveTestResults(testResult) {
  */
 async function getRunsForCycleAndUser(cycleId, userId) {
     try {
-
         // We need to get all the runs for which the user has been configured
         // or for which there is an AT that the user can test
         let runs = (
@@ -414,9 +414,10 @@ async function getRunsForCycleAndUser(cycleId, userId) {
         let runsById = {};
 
         for (let run of runs) {
-            runsById[run.id] = {tests: []};
+            runsById[run.id] = { tests: [] };
 
-            let tests = (await sequelize.query(`
+            let tests = (
+                await sequelize.query(`
               select
                 id,
                 name,
@@ -428,9 +429,11 @@ async function getRunsForCycleAndUser(cycleId, userId) {
                 test.apg_example_id = ${run.apg_example_id}
               order by
                 execution_order
-            `))[0];
+            `)
+            )[0];
 
-            let test_results = (await sequelize.query(`
+            let test_results = (
+                await sequelize.query(`
               select
                 test_result.id as id,
                 test_result.result as result,
@@ -443,7 +446,8 @@ async function getRunsForCycleAndUser(cycleId, userId) {
                 test_result.status_id = test_status.id
                 and test_result.run_id = ${run.id}
                 and test_result.user_id = ${userId}
-            `))[0];
+            `)
+            )[0];
 
             for (let test of tests) {
                 let results = test_results.filter(r => r.test_id === test.id);
@@ -453,7 +457,7 @@ async function getRunsForCycleAndUser(cycleId, userId) {
                         result: results[0].result,
                         status: results[0].status,
                         user_id: userId
-                    }
+                    };
                 }
                 runsById[run.id].tests.push(test);
             }

--- a/server/services/CycleService.js
+++ b/server/services/CycleService.js
@@ -152,6 +152,7 @@ async function configureCycle(cycle) {
  *           at_version,
  *           apg_example_directory,
  *           apg_example_name
+ *           users: [user_id, user_id]
  *         }
  *       ]
  *     };
@@ -176,6 +177,21 @@ async function getAllCycles(id) {
                     run_data.test_cycle_id = ${cycle.id}
             `)
             )[0];
+
+            for (let run of runs) {
+                let users = (
+                    await sequelize.query(`
+                  select
+                    user_id
+                  from
+                    tester_to_run
+                  where
+                    tester_to_run.run_id = ${run.id}
+                `)
+                )[0];
+
+                run.user = users.map(u => u.user_id);
+            }
 
             cycle.runs = runs;
         }
@@ -294,9 +310,167 @@ async function getAllTestVersions() {
     }
 }
 
+
+/**
+ * Saves a test result and marks the test as "complete"
+ *
+ * @param {object} result - result object to save
+ * @return {object} - the saved result object (the same data, now with "id" and "status: complete")
+ *
+ * @example
+ *
+ *     result = {
+ *       test_id,
+ *       run_id,
+ *       user_id,
+ *       result
+ *     };
+ */
+async function saveTestResults(testResult) {
+    try {
+        let statusId = (
+            await sequelize.query(`
+             SELECT
+               id
+             FROM
+               test_status
+             WHERE
+               test_status.name = 'complete'
+        `)
+        )[0][0].id;
+
+        let testResultId = (
+            await sequelize.query(`
+             INSERT INTO
+               test_result(test_id, run_id, user_id, status_id, result)
+             VALUES
+               (${testResult.test_id}, ${testResult.run_id}, ${testResult.user_id}, ${statusId}, ${testResult.result ? testResult.result : "NULL"})
+             RETURNING ID
+        `)
+        )[0];
+
+        testResult.id = testResultId;
+        testResult.status = 'complete';
+        return testResult;
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
+/**
+ * Gets all the runs that a user is assigned to or can perform within a cycle
+ *
+ * @param {int} cycleId - cycle id
+ * @param {int} userId - user id
+ * @return {object} - list of tests (with save test result data if it exists) keyed by runs
+ *
+ * @example
+ *
+ *    {
+ *      run_id: {
+ *        tests:[{
+ *            id               // test.id
+ *            name             // test.name
+ *            file             // test.file
+ *            execution_order
+ *            test_result : {
+ *              test_result_id
+ *              user_id
+ *              status_id
+ *              result
+ *            }
+ *          }]
+ *        }
+ *      }
+ *    }
+ */
+async function getRunsForCycleAndUser(cycleId, userId) {
+    try {
+
+        // We need to get all the runs for which the user has been configured
+        // or for which there is an AT that the user can test
+        let runs = (
+            await sequelize.query(`
+              select
+                *
+              from
+                run_data
+              where
+                run_data.test_cycle_id = ${cycleId}
+                and run_data.at_name in (
+                  select
+                    at_name.name
+                  from
+                    at_name,
+                    user_to_at
+                  where
+                    user_to_at.at_name_id = at_name.id
+                    and user_to_at.user_id = ${userId}
+                )
+        `)
+        )[0];
+
+        let runsById = {};
+
+        for (let run of runs) {
+            runsById[run.id] = {tests: []};
+
+            let tests = (await sequelize.query(`
+              select
+                id,
+                name,
+                file,
+                execution_order
+              from
+                test
+              where
+                test.apg_example_id = ${run.apg_example_id}
+              order by
+                execution_order
+            `))[0];
+
+            let test_results = (await sequelize.query(`
+              select
+                test_result.id as id,
+                test_result.result as result,
+                test_result.test_id as test_id,
+                test_status.name as status
+              from
+                test_result,
+                test_status
+              where
+                test_result.status_id = test_status.id
+                and test_result.run_id = ${run.id}
+                and test_result.user_id = ${userId}
+            `))[0];
+
+            for (let test of tests) {
+                let results = test_results.filter(r => r.test_id === test.id);
+                if (results.length === 1) {
+                    test.result = {
+                        id: results[0].id,
+                        result: results[0].result,
+                        status: results[0].status,
+                        user_id: userId
+                    }
+                }
+                runsById[run.id].tests.push(test);
+            }
+        }
+
+        return runsById;
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
 module.exports = {
     configureCycle,
     getAllCycles,
     deleteCycle,
-    getAllTestVersions
+    getAllTestVersions,
+    getRunsForCycleAndUser,
+    saveTestResults
 };


### PR DESCRIPTION
Hey Erika, you or I will need to add a route to "skip" a test in the future, I didn't get to it today and figured we could add when that feature is being built out.

Otherwise, before merging to master or checking, you are going to have to manually unwind on migration. I wanted to add more data to a view! You should be able to do the following:
```
psql
> delete from flyway_schema_history where version='4';
> drop view run_data;
> exit

yarn db-migrate:dev
```

To test the new routes, you will need to populate the database with cycles and things... which makes me think maybe I should clean up the cycle initiation PR first thing tmr so you can use the front end to populate cycles.

Once there is data, you can test:
```
curl --location --request GET 'localhost:5000/api/cycle/runs' --header 'Content-Type: application/json' --data-raw '{"cycle_id": 24, "user_id": 1}'

curl --location --request POST 'localhost:5000/api/cycle/result' --header 'Content-Type: application/json' --data-raw '{"test_id": 90, "run_id": 14, "user_id": 1}'
``` 