### PR TITLE
Minor changes to routes, top navigation and add titles

### DIFF
--- a/client/components/App/index.jsx
+++ b/client/components/App/index.jsx
@@ -51,23 +51,25 @@ class App extends Component {
                                     </Nav.Link>
                                 </React.Fragment>
                             )) || (
-                                <Nav.Link
-                                    as={Link}
-                                    to="/"
-                                    onClick={this.logout}
-                                >
-                                    Logout
-                                </Nav.Link>
+                                <React.Fragment>
+                                    <Nav.Link as={Link} to="/cycles">
+                                        Test Management
+                                    </Nav.Link>
+                                    <Nav.Link as={Link} to="/test-queue">
+                                        Test Queue
+                                    </Nav.Link>
+                                    <Nav.Link as={Link} to="/account/settings">
+                                        Settings
+                                    </Nav.Link>
+                                    <Nav.Link
+                                        as={Link}
+                                        to="/"
+                                        onClick={this.logout}
+                                    >
+                                        Logout
+                                    </Nav.Link>
+                                </React.Fragment>
                             )}
-                            <Nav.Link as={Link} to="/account/settings">
-                                Settings
-                            </Nav.Link>
-                            <Nav.Link as={Link} to="/cycles">
-                                Testing Cycle Management
-                            </Nav.Link>
-                            <Nav.Link as={Link} to="/tester-home">
-                                Tester Home
-                            </Nav.Link>
                         </Navbar.Collapse>
                     </Navbar>
                 </Container>

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Table } from 'react-bootstrap';
+import { Helmet } from 'react-helmet';
 import {
     getTestSuiteVersions,
     getTestCycles,
@@ -79,6 +80,9 @@ class CycleSummary extends Component {
 
         return (
             <Fragment>
+              <Helmet>
+                <title>Test Management (for cycle: {cycle.name}) | ARIA-AT</title>
+              </Helmet>
                 <h2>{cycle.name} - Status</h2>
                 <h3>Git commit of tests</h3>
                 <p>{`${

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -80,9 +80,11 @@ class CycleSummary extends Component {
 
         return (
             <Fragment>
-              <Helmet>
-                <title>Test Management (for cycle: {cycle.name}) | ARIA-AT</title>
-              </Helmet>
+                <Helmet>
+                    <title>
+                        Test Management (for cycle: {cycle.name}) | ARIA-AT
+                    </title>
+                </Helmet>
                 <h2>{cycle.name} - Status</h2>
                 <h3>Git commit of tests</h3>
                 <p>{`${

--- a/client/components/ManageCycleRow/index.jsx
+++ b/client/components/ManageCycleRow/index.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { Button } from 'react-bootstrap';
 import { deleteCycle } from '../../actions/cycles';
 
-class CycleRow extends Component {
+class ManageCycleRow extends Component {
     constructor(props) {
         super(props);
         this.deleteCycle = this.deleteCycle.bind(this);
@@ -21,7 +21,7 @@ class CycleRow extends Component {
         return (
             <tr>
                 <td>
-                    <Link to={`/cycle/${id}/summary`}>{name}</Link>
+                    <Link to={`/cycles/${id}`}>{name}</Link>
                 </td>
                 <td>{date}</td>
                 <td>In Progress</td>
@@ -33,9 +33,9 @@ class CycleRow extends Component {
     }
 }
 
-CycleRow.propTypes = {
+ManageCycleRow.propTypes = {
     cycle: PropTypes.object,
     dispatch: PropTypes.func
 };
 
-export default connect()(CycleRow);
+export default connect()(ManageCycleRow);

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
-import CycleRow from '@components/CycleRow';
+import ManageCycleRow from '@components/ManageCycleRow';
 import { getTestCycles } from '../../actions/cycles';
 
 class ManageCycles extends Component {
@@ -19,7 +19,7 @@ class ManageCycles extends Component {
         return (
             <Fragment>
                 <h2>Initiate a Test Cycle</h2>
-                <Button as={Link} to="/initiate-cycle">
+                <Button as={Link} to="/new">
                     Initiate
                 </Button>
                 <h2>Test Cycle Status</h2>
@@ -34,7 +34,7 @@ class ManageCycles extends Component {
                     </thead>
                     <tbody>
                         {Object.keys(cyclesById).map(cycleId => (
-                            <CycleRow
+                            <ManageCycleRow
                                 key={cycleId}
                                 cycle={cyclesById[cycleId]}
                             />

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -19,9 +19,9 @@ class ManageCycles extends Component {
         const { cyclesById } = this.props;
         return (
             <Fragment>
-              <Helmet>
-                <title>Test Management | ARIA-AT</title>
-              </Helmet>
+                <Helmet>
+                    <title>Test Management | ARIA-AT</title>
+                </Helmet>
                 <h2>Initiate a Test Cycle</h2>
                 <Button as={Link} to="/new">
                     Initiate

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
 import ManageCycleRow from '@components/ManageCycleRow';
@@ -18,6 +19,9 @@ class ManageCycles extends Component {
         const { cyclesById } = this.props;
         return (
             <Fragment>
+              <Helmet>
+                <title>Test Management | ARIA-AT</title>
+              </Helmet>
                 <h2>Initiate a Test Cycle</h2>
                 <Button as={Link} to="/new">
                     Initiate

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -1,8 +1,9 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { Table } from 'react-bootstrap';
+import { Helmet } from "react-helmet";
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { Table } from 'react-bootstrap';
 import { getTestCycles, getRunsForUserAndCycle } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
 
@@ -114,6 +115,9 @@ class TestQueue extends Component {
 
         return (
             <Fragment>
+                <Helmet>
+                  <title>{`Test queue (for cycle: ${cycle.name}) | ARIA-AT`}</title>
+                </Helmet>
                 <h2>
                     Test Run Queue For Test Cycle:{' '}
                     {cycle ? cycle.name : cycleId}

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
-import { Helmet } from "react-helmet";
+import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { getTestCycles, getRunsForUserAndCycle } from '../../actions/cycles';
@@ -116,7 +116,7 @@ class TestQueue extends Component {
         return (
             <Fragment>
                 <Helmet>
-                  <title>{`Test queue (for cycle: ${cycle.name}) | ARIA-AT`}</title>
+                    <title>{`Test queue (for cycle: ${cycle.name}) | ARIA-AT`}</title>
                 </Helmet>
                 <h2>
                     Test Run Queue For Test Cycle:{' '}

--- a/client/components/TesterHome/index.jsx
+++ b/client/components/TesterHome/index.jsx
@@ -19,7 +19,7 @@ class TesterHome extends Component {
         return (
             <Fragment>
                 <Helmet>
-                  <title>Test Queue (for all cycles) | ARIA-AT</title>
+                    <title>Test Queue (for all cycles) | ARIA-AT</title>
                 </Helmet>
                 <h2>Test Cycles</h2>
                 <Table striped bordered hover>

--- a/client/components/TesterHome/index.jsx
+++ b/client/components/TesterHome/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
 import { getTestCycles } from '../../actions/cycles';
@@ -17,6 +18,9 @@ class TesterHome extends Component {
         const { cyclesById } = this.props;
         return (
             <Fragment>
+                <Helmet>
+                  <title>Test Queue (for all cycles) | ARIA-AT</title>
+                </Helmet>
                 <h2>Test Cycles</h2>
                 <Table striped bordered hover>
                     <thead>

--- a/client/components/TesterHome/index.jsx
+++ b/client/components/TesterHome/index.jsx
@@ -36,7 +36,7 @@ class TesterHome extends Component {
                                 <td>
                                     <Button
                                         as={Link}
-                                        to={`/cycle/${cycleId}/test-queue`}
+                                        to={`/test-queue/${cycleId}`}
                                     >
                                         Contribute Tests
                                     </Button>

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "bootstrap": "^4.4.1",
     "node-sass": "^4.13.1",
     "react-bootstrap": "^1.0.0",
+    "react-helmet": "^6.0.0",
     "sass-loader": "^8.0.2"
   },
   "devDependencies": {

--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -40,20 +40,20 @@ export default [
                 component: ManageCycles
             },
             {
-                path: '/cycle/:cycleId/test-queue',
+                path: '/test-queue/:cycleId',
                 component: TestQueue
             },
             {
-                path: '/tester-home',
+                path: '/test-queue',
                 exact: true,
                 component: TesterHome
             },
             {
-                path: '/cycle/:cycleId/summary',
+                path: '/cycles/:cycleId',
                 component: CycleSummary
             },
             {
-                path: '/initiate-cycle',
+                path: '/cycles/new',
                 exact: true,
                 component: InitiateCycle
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10937,6 +10937,16 @@ react-helmet-async@^1.0.2:
     react-fast-compare "^2.0.4"
     shallowequal "^1.1.0"
 
+react-helmet@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.0.0.tgz#fcb93ebaca3ba562a686eb2f1f9d46093d83b5f8"
+  integrity sha512-My6S4sa0uHN/IuVUn0HFmasW5xj9clTkB9qmMngscVycQ5vVG51Qp44BEvLJ4lixupTwDlU9qX1/sCrMN4AEPg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^2.0.4"
+    react-side-effect "^2.1.0"
+
 react-hotkeys@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-2.0.0.tgz#a7719c7340cbba888b0e9184f806a9ec0ac2c53f"
@@ -11043,6 +11053,11 @@ react-router@5.1.2:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-side-effect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
+  integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
 react-sizeme@^2.6.7:
   version "2.6.12"


### PR DESCRIPTION
In the spirit of small PRs! This PR does  a few things:
1. Rename the routes to be similar to what we discussed with Seth, but slightly different. Right now we have two different pages (or URLs) for the performing tests and managing test cycles.
2. Add titles to every page with Helmet, we should always do this going forward, important for accessibility
3. Renamed a view
4. Don't display pages in top nav when you are logged out