### PR TITLE
Everytime a user logs in, set their roles according to the github teams

### DIFF
--- a/client/components/App/index.jsx
+++ b/client/components/App/index.jsx
@@ -28,7 +28,7 @@ class App extends Component {
     }
 
     render() {
-        const { route, isLoggedIn } = this.props;
+        const { route, isLoggedIn, isAdmin, isTester } = this.props;
         return (
             <Fragment>
                 <Container fluid>
@@ -52,12 +52,16 @@ class App extends Component {
                                 </React.Fragment>
                             )) || (
                                 <React.Fragment>
-                                    <Nav.Link as={Link} to="/cycles">
-                                        Test Management
-                                    </Nav.Link>
-                                    <Nav.Link as={Link} to="/test-queue">
-                                        Test Queue
-                                    </Nav.Link>
+                                    {isAdmin && (
+                                        <Nav.Link as={Link} to="/cycles">
+                                            Test Management
+                                        </Nav.Link>
+                                    )}
+                                    {isTester && (
+                                        <Nav.Link as={Link} to="/test-queue">
+                                            Test Queue
+                                        </Nav.Link>
+                                    )}
                                     <Nav.Link as={Link} to="/account/settings">
                                         Settings
                                     </Nav.Link>
@@ -82,13 +86,17 @@ class App extends Component {
 App.propTypes = {
     dispatch: PropTypes.func,
     isLoggedIn: PropTypes.bool,
+    isAdmin: PropTypes.bool,
+    isTester: PropTypes.bool,
     location: PropTypes.object,
     route: PropTypes.object
 };
 
 const mapStateToProps = state => {
-    const { isLoggedIn } = state.login;
-    return { isLoggedIn };
+    const { isLoggedIn, roles } = state.login;
+    let isAdmin = roles ? roles.includes('admin') : false;
+    let isTester = isAdmin || (roles && roles.includes('tester'));
+    return { isLoggedIn, isAdmin, isTester };
 };
 
 export default connect(mapStateToProps)(App);

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
 import ConfigureRunsForExample from '@components/ConfigureRunsForExample';
+import { Redirect } from 'react-router-dom';
 
 class CycleSummary extends Component {
     constructor(props) {
@@ -46,7 +47,11 @@ class CycleSummary extends Component {
     }
 
     render() {
-        const { cycle, users, testSuiteVersionData } = this.props;
+        const { cycle, isAdmin, users, testSuiteVersionData } = this.props;
+
+        if (!isAdmin) {
+            return <Redirect to={{ pathname: '/404'}} />;
+        }
 
         if (!cycle || !testSuiteVersionData) {
             return <div>LOADING</div>;
@@ -139,12 +144,16 @@ CycleSummary.propTypes = {
     cycle: PropTypes.object,
     dispatch: PropTypes.func,
     users: PropTypes.array,
+    isAdmin: PropTypes.bool,
     testSuiteVersionData: PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => {
+    const { roles } = state.login;
     const { cyclesById, testSuiteVersions } = state.cycles;
     const { users } = state.users;
+
+    let isAdmin = roles ? roles.includes('admin') : false;
 
     const cycleId = parseInt(ownProps.match.params.cycleId);
 

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -50,7 +50,7 @@ class CycleSummary extends Component {
         const { cycle, isAdmin, users, testSuiteVersionData } = this.props;
 
         if (!isAdmin) {
-            return <Redirect to={{ pathname: '/404'}} />;
+            return <Redirect to={{ pathname: '/404' }} />;
         }
 
         if (!cycle || !testSuiteVersionData) {

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -165,7 +165,7 @@ const mapStateToProps = (state, ownProps) => {
         );
     }
 
-    return { cycle, users, testSuiteVersionData };
+    return { cycle, users, testSuiteVersionData, isAdmin };
 };
 
 export default connect(mapStateToProps)(CycleSummary);

--- a/client/components/Home/index.jsx
+++ b/client/components/Home/index.jsx
@@ -2,9 +2,7 @@ import React, { Component } from 'react';
 
 class Home extends Component {
     render() {
-        return (
-            <h1>Home Page</h1>
-        );
+        return <h1>Home Page</h1>;
     }
 }
 

--- a/client/components/Home/index.jsx
+++ b/client/components/Home/index.jsx
@@ -1,0 +1,11 @@
+import React, { Component } from 'react';
+
+class Home extends Component {
+    render() {
+        return (
+            <h1>Home Page</h1>
+        );
+    }
+}
+
+export default Home;

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -229,7 +229,7 @@ class InitiateCycle extends Component {
         const { testSuiteVersions, users, isAdmin } = this.props;
 
         if (!isAdmin) {
-            return <Redirect to={{ pathname: '/404'}} />;
+            return <Redirect to={{ pathname: '/404' }} />;
         }
 
         if (!testSuiteVersions.length) {

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -6,6 +6,7 @@ import { getTestSuiteVersions, saveCycle } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
 import ConfigureTechnologyRow from '@components/ConfigureTechnologyRow';
 import ConfigureRunsForExample from '@components/ConfigureRunsForExample';
+import { Redirect } from 'react-router-dom';
 
 class InitiateCycle extends Component {
     constructor(props) {
@@ -225,7 +226,11 @@ class InitiateCycle extends Component {
     }
 
     render() {
-        const { testSuiteVersions, users } = this.props;
+        const { testSuiteVersions, users, isAdmin } = this.props;
+
+        if (!isAdmin) {
+            return <Redirect to={{ pathname: '/404'}} />;
+        }
 
         if (!testSuiteVersions.length) {
             return <div>LOADING</div>;
@@ -349,12 +354,17 @@ InitiateCycle.propTypes = {
     testSuiteVersions: PropTypes.array,
     dispatch: PropTypes.func,
     history: PropTypes.object,
+    isAdmin: PropTypes.bool,
     users: PropTypes.array
 };
 
 const mapStateToProps = state => {
     const { testSuiteVersions } = state.cycles;
     const { users } = state.users;
+    const { roles } = state.login;
+
+    let isAdmin = roles ? roles.includes('admin') : false;
+
     return { testSuiteVersions, users };
 };
 

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -365,7 +365,7 @@ const mapStateToProps = state => {
 
     let isAdmin = roles ? roles.includes('admin') : false;
 
-    return { testSuiteVersions, users };
+    return { testSuiteVersions, users, isAdmin };
 };
 
 export default connect(mapStateToProps)(InitiateCycle);

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -20,7 +20,7 @@ class ManageCycles extends Component {
         const { cyclesById, isAdmin } = this.props;
 
         if (!isAdmin) {
-            return <Redirect to={{ pathname: '/'}} />;
+            return <Redirect to={{ pathname: '/404'}} />;
         }
 
         return (

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
 import ManageCycleRow from '@components/ManageCycleRow';
 import { getTestCycles } from '../../actions/cycles';
+import { Redirect } from 'react-router-dom';
 
 class ManageCycles extends Component {
     componentDidMount() {
@@ -16,7 +17,12 @@ class ManageCycles extends Component {
     }
 
     render() {
-        const { cyclesById } = this.props;
+        const { cyclesById, isAdmin } = this.props;
+
+        if (!isAdmin) {
+            return <Redirect to={{ pathname: '/'}} />;
+        }
+
         return (
             <Fragment>
                 <Helmet>
@@ -52,12 +58,17 @@ class ManageCycles extends Component {
 
 ManageCycles.propTypes = {
     cyclesById: PropTypes.object,
-    dispatch: PropTypes.func
+    dispatch: PropTypes.func,
+    isAdmin: PropTypes.bool
 };
 
 const mapStateToProps = state => {
+    const { roles } = state.login;
     const { cyclesById } = state.cycles;
-    return { cyclesById };
+
+    let isAdmin = roles ? roles.includes('admin') : false;
+
+    return { cyclesById, isAdmin };
 };
 
 export default connect(mapStateToProps)(ManageCycles);

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -20,7 +20,7 @@ class ManageCycles extends Component {
         const { cyclesById, isAdmin } = this.props;
 
         if (!isAdmin) {
-            return <Redirect to={{ pathname: '/404'}} />;
+            return <Redirect to={{ pathname: '/404' }} />;
         }
 
         return (

--- a/client/components/NotFound/index.jsx
+++ b/client/components/NotFound/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const NotFound = () => {
+  return (
+    <section className="not-found">
+      <div>
+        <h1>Whoooops! Page not found</h1>
+      </div>
+    </section>
+  );
+};
+
+export default NotFound;

--- a/client/components/NotFound/index.jsx
+++ b/client/components/NotFound/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 const NotFound = () => {
-  return (
-    <section className="not-found">
-      <div>
-        <h1>Whoooops! Page not found</h1>
-      </div>
-    </section>
-  );
+    return (
+        <section className="not-found">
+            <div>
+                <h1>Whoooops! Page not found</h1>
+            </div>
+        </section>
+    );
 };
 
 export default NotFound;

--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -15,7 +15,6 @@ import TestQueue from '@components/TestQueue';
 import TestRun from '@components/TestRun';
 import UserSettings from '@components/UserSettings';
 
-
 export default [
     {
         component: App,
@@ -23,7 +22,7 @@ export default [
             {
                 path: '/',
                 exact: true,
-                component: Home,
+                component: Home
             },
             {
                 path: '/login',
@@ -81,9 +80,8 @@ export default [
             },
             {
                 component: () => {
-                    return <Redirect to={{ pathname: '/404'}} />;
+                    return <Redirect to={{ pathname: '/404' }} />;
                 }
-
             }
         ]
     }

--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -1,19 +1,30 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
 import App from '@components/App';
+import CycleSummary from '@components/CycleSummary';
+import Home from '@components/Home';
+import InitiateCycle from '@components/InitiateCycle';
 import Login from '@components/Login';
+import ManageCycles from '@components/ManageCycles';
+import NotFound from '@components/NotFound';
 import Signup from '@components/Signup';
 import SignupInstructions from '@components/SignupInstructions';
-import UserSettings from '@components/UserSettings';
-import ManageCycles from '@components/ManageCycles';
-import InitiateCycle from '@components/InitiateCycle';
 import TesterHome from '@components/TesterHome';
 import TestQueue from '@components/TestQueue';
 import TestRun from '@components/TestRun';
-import CycleSummary from '@components/CycleSummary';
+import UserSettings from '@components/UserSettings';
+
 
 export default [
     {
         component: App,
         routes: [
+            {
+                path: '/',
+                exact: true,
+                component: Home,
+            },
             {
                 path: '/login',
                 exact: true,
@@ -62,6 +73,17 @@ export default [
             {
                 path: '/cycles/:cycleId(\\d+)/run/:runId(\\d+)',
                 component: TestRun
+            },
+            {
+                path: '/404',
+                exact: true,
+                component: NotFound
+            },
+            {
+                component: () => {
+                    return <Redirect to={{ pathname: '/404'}} />;
+                }
+
             }
         ]
     }

--- a/server/controllers/AuthController.js
+++ b/server/controllers/AuthController.js
@@ -59,10 +59,14 @@ module.exports = {
             }
         } else if (req.session.authType === LOGIN) {
             const { name: fullname, username, email } = userToAuthorize;
-            const dbUser = await services.UsersService.getUser({
-                fullname,
-                username,
-                email
+
+            const dbUser = await services.UsersService.getUserAndUpdateRoles({
+                accessToken: req.session.accessToken,
+                user: {
+                    fullname,
+                    username,
+                    email
+                }
             });
             if (dbUser) {
                 authorized = true;

--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -96,7 +96,10 @@ const ariaat = {
                         test !== 'index.html'
                     ) {
                         // Get the test name from the html file
-                        const htmlFile = path.relative(tmpDirectory, testFullPath);
+                        const htmlFile = path.relative(
+                            tmpDirectory,
+                            testFullPath
+                        );
                         const root = np.parse(
                             fse.readFileSync(testFullPath, 'utf8'),
                             { script: true }
@@ -116,7 +119,10 @@ const ariaat = {
                         );
 
                         const testBaseName = path.basename(test, '.html');
-                        const jsonFile =  path.join(subDirFullPath, `${testBaseName}.json`);
+                        const jsonFile = path.join(
+                            subDirFullPath,
+                            `${testBaseName}.json`
+                        );
                         const testData = JSON.parse(
                             fse.readFileSync(jsonFile, 'utf8')
                         );
@@ -124,9 +130,10 @@ const ariaat = {
                         let appliesToList = [];
                         for (let a of testData.applies_to) {
                             if (support.applies_to[a]) {
-                                appliesToList = appliesToList.concat(support.applies_to[a]);
-                            }
-                            else {
+                                appliesToList = appliesToList.concat(
+                                    support.applies_to[a]
+                                );
+                            } else {
                                 appliesToList.push(a);
                             }
                         }
@@ -247,7 +254,13 @@ const ariaat = {
      * @param {int} executionOrder - order of the tests (within APG pattern)
      * @return {int} id
      */
-    async upsertTest(testFullName, file, exampleID, testVersionID, executionOrder) {
+    async upsertTest(
+        testFullName,
+        file,
+        exampleID,
+        testVersionID,
+        executionOrder
+    ) {
         const testResult = await client.query(
             'SELECT id FROM test WHERE file=$1 AND test_version_id=$2',
             [file, testVersionID]

--- a/server/services/UsersService.js
+++ b/server/services/UsersService.js
@@ -57,7 +57,7 @@ async function addUserToRole(userToRole) {
 
 async function deleteUserFromRole(userToRole) {
     try {
-        const newUserToRole = await UserToRole.destroy({
+        await UserToRole.destroy({
             where: userToRole
         });
     } catch (error) {

--- a/server/services/__mocks__/UsersService.js
+++ b/server/services/__mocks__/UsersService.js
@@ -10,6 +10,9 @@ const UsersService = {
     getUser(options) {
         return options;
     },
+    getUserAndUpdateRoles(options) {
+        return options;
+    },
     getAllTesters() {
         return [
             {


### PR DESCRIPTION
To test you will be adding and removing yourself from the following teams:
- [admin team](https://github.com/orgs/bocoup/teams/aria-at-report-admin/members)
- [tester team](https://github.com/orgs/bocoup/teams/aria-at-report-testers/members)

1. Add yourself to the tester team, but remove yourself from the admin team
    - log out
    - log back in
    - you should see the "test queue" but not the "test cycle management"
    - there should be no entry for you in the `user_to_role` table where `role_id `is the admin role.
    - you cannot go to pages "/cycles/new" or "/cycles" -- you get redirected to 404 page

2. Add yourself to the admin team and remove yourself from the tester team.
    - log out
    - log back in
    - you should see the "test queue" and the "test cycle management" (an admin is sort of like a tester by default)
    - there should be no entry for you in the `user_to_role` table where `role_id `is the tester role.

3. Remove yourself from both admin and tester team
   - log out
   - log back in
   - you should see no options, just a log out option
