### PR TITLE
Add ability to assign users in test queue

### DIFF
--- a/client/actions/users.js
+++ b/client/actions/users.js
@@ -18,11 +18,11 @@ export function getAllUsers() {
     };
 }
 
-export function handleSetUserAts(user, ats) {
+export function handleSetUserAts(userId, ats) {
     return async function(dispatch) {
-        const response = await axios.post('/api/user/ats', { user, ats });
+        const response = await axios.post('/api/user/ats', { userId, ats });
         if (response.status === 200) {
-            dispatch(setUserAts({ user, ats: response.data }));
+            dispatch(setUserAts({ userId, ats: response.data }));
         }
     };
 }

--- a/client/components/ConfigureRunsForExample/index.jsx
+++ b/client/components/ConfigureRunsForExample/index.jsx
@@ -21,7 +21,7 @@ class ConfigureRunsForExample extends Component {
             removeAllTestersFromRun,
             testersByRunId,
             example,
-            users,
+            usersById,
             runs
         } = this.props;
         let value = parseInt(event.currentTarget.value);
@@ -61,7 +61,7 @@ class ConfigureRunsForExample extends Component {
                 // Make sure the user can be assigned to this run
                 runId = parseInt(runId);
                 const atName = runs.find(r => r.id === runId).at_name;
-                const userAts = users.find(u => u.id === value).configured_ats;
+                const userAts = usersById[value].configured_ats;
                 if (userAts.find(ua => ua.at_name === atName && ua.active)) {
                     runIds.push(runId);
                 }
@@ -85,7 +85,7 @@ class ConfigureRunsForExample extends Component {
     }
 
     render() {
-        const { example, users, testersByRunId, runs } = this.props;
+        const { example, usersById, testersByRunId, runs } = this.props;
 
         runs.sort(function(a, b) {
             if (a.at_id === b.at_id) {
@@ -115,9 +115,7 @@ class ConfigureRunsForExample extends Component {
                                 if (testersByRunId && testersByRunId[run.id]) {
                                     names = testersByRunId[run.id].map(
                                         testerId => {
-                                            let user = users.filter(
-                                                u => u.id === testerId
-                                            )[0];
+                                            let user = usersById[testerId];
                                             return user.fullname;
                                         }
                                     );
@@ -169,13 +167,10 @@ class ConfigureRunsForExample extends Component {
                                             Clear Assignees
                                         </option>
                                         ;
-                                        {users.map(user => {
+                                        {Object.keys(usersById).map(id => {
                                             return (
-                                                <option
-                                                    key={user.id}
-                                                    value={user.id}
-                                                >
-                                                    {user.fullname}
+                                                <option key={id} value={id}>
+                                                    {usersById[id].fullname}
                                                 </option>
                                             );
                                         })}
@@ -198,7 +193,7 @@ class ConfigureRunsForExample extends Component {
 
 ConfigureRunsForExample.propTypes = {
     example: PropTypes.object,
-    users: PropTypes.array,
+    usersById: PropTypes.object,
     assignTesters: PropTypes.func,
     removeAllTestersFromRun: PropTypes.func,
     testersByRunId: PropTypes.object,

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -22,12 +22,12 @@ class CycleSummary extends Component {
     }
 
     componentDidMount() {
-        const { dispatch, cycle, users, testSuiteVersionData } = this.props;
+        const { dispatch, cycle, usersById, testSuiteVersionData } = this.props;
 
         if (!cycle) {
             dispatch(getTestCycles());
         }
-        if (!users.length) {
+        if (!Object.keys(usersById).length) {
             dispatch(getAllUsers());
         }
         if (!testSuiteVersionData) {
@@ -47,7 +47,7 @@ class CycleSummary extends Component {
     }
 
     render() {
-        const { cycle, isAdmin, users, testSuiteVersionData } = this.props;
+        const { cycle, isAdmin, usersById, testSuiteVersionData } = this.props;
 
         if (!isAdmin) {
             return <Redirect to={{ pathname: '/404' }} />;
@@ -126,7 +126,7 @@ class CycleSummary extends Component {
                                 runs={runsByExample[example.id]}
                                 key={example.id}
                                 example={example}
-                                users={users}
+                                usersById={usersById}
                                 assignTesters={this.assignTesters}
                                 removeAllTestersFromRun={
                                     this.removeAllTestersFromRun
@@ -143,7 +143,7 @@ class CycleSummary extends Component {
 CycleSummary.propTypes = {
     cycle: PropTypes.object,
     dispatch: PropTypes.func,
-    users: PropTypes.array,
+    usersById: PropTypes.object,
     isAdmin: PropTypes.bool,
     testSuiteVersionData: PropTypes.object
 };
@@ -151,7 +151,7 @@ CycleSummary.propTypes = {
 const mapStateToProps = (state, ownProps) => {
     const { roles } = state.login;
     const { cyclesById, testSuiteVersions } = state.cycles;
-    const { users } = state.users;
+    const { usersById } = state.users;
 
     let isAdmin = roles ? roles.includes('admin') : false;
 
@@ -165,7 +165,7 @@ const mapStateToProps = (state, ownProps) => {
         );
     }
 
-    return { cycle, users, testSuiteVersionData, isAdmin };
+    return { cycle, usersById, testSuiteVersionData, isAdmin };
 };
 
 export default connect(mapStateToProps)(CycleSummary);

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -33,12 +33,12 @@ class InitiateCycle extends Component {
     }
 
     componentDidMount() {
-        const { dispatch, testSuiteVersions, users } = this.props;
+        const { dispatch, testSuiteVersions, usersById } = this.props;
 
         if (!testSuiteVersions.length) {
             dispatch(getTestSuiteVersions());
         }
-        if (!users.length) {
+        if (!Object.keys(usersById).length) {
             dispatch(getAllUsers());
         }
     }
@@ -226,7 +226,7 @@ class InitiateCycle extends Component {
     }
 
     render() {
-        const { testSuiteVersions, users, isAdmin } = this.props;
+        const { testSuiteVersions, usersById, isAdmin } = this.props;
 
         if (!isAdmin) {
             return <Redirect to={{ pathname: '/404' }} />;
@@ -331,7 +331,7 @@ class InitiateCycle extends Component {
                                 runs={runs}
                                 key={example.id}
                                 example={example}
-                                users={users}
+                                usersById={usersById}
                                 assignTesters={this.assignTesters}
                                 removeAllTestersFromRun={
                                     this.removeAllTestersFromRun
@@ -355,17 +355,17 @@ InitiateCycle.propTypes = {
     dispatch: PropTypes.func,
     history: PropTypes.object,
     isAdmin: PropTypes.bool,
-    users: PropTypes.array
+    usersById: PropTypes.object
 };
 
 const mapStateToProps = state => {
     const { testSuiteVersions } = state.cycles;
-    const { users } = state.users;
+    const { usersById } = state.users;
     const { roles } = state.login;
 
     let isAdmin = roles ? roles.includes('admin') : false;
 
-    return { testSuiteVersions, users, isAdmin };
+    return { testSuiteVersions, usersById, isAdmin };
 };
 
 export default connect(mapStateToProps)(InitiateCycle);

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -9,12 +9,18 @@ import { getAllUsers } from '../../actions/users';
 
 class TestQueue extends Component {
     componentDidMount() {
-        const { dispatch, cycle, cycleId, testsForRuns, users } = this.props;
+        const {
+            dispatch,
+            cycle,
+            cycleId,
+            testsForRuns,
+            usersById
+        } = this.props;
         if (!cycle) {
             dispatch(getTestCycles());
         }
 
-        if (!users.length) {
+        if (!Object.keys(usersById).length) {
             dispatch(getAllUsers());
         }
 
@@ -24,13 +30,13 @@ class TestQueue extends Component {
     }
 
     renderRunRow(run) {
-        const { cycleId, userId, users } = this.props;
+        const { cycleId, userId, usersById } = this.props;
 
         let currentUserAssigned = run.testers.includes(userId);
 
         // TODO: Fix when users is a mapped id => user object
         let userNames = run.testers.map(uid => {
-            return users.find(u => u.id === uid).fullname;
+            return usersById[uid].fullname;
         });
 
         let designPatternLinkOrName;
@@ -76,13 +82,13 @@ class TestQueue extends Component {
     }
 
     render() {
-        const { cycle, cycleId, testsForRuns, users, userId } = this.props;
+        const { cycle, cycleId, testsForRuns, usersById, userId } = this.props;
 
-        if (!testsForRuns || !cycle || !users.length) {
+        if (!testsForRuns || !cycle || !Object.keys(usersById).length) {
             return <div>Loading</div>;
         }
 
-        let currentUser = users.find(u => u.id === userId);
+        let currentUser = usersById[userId];
         let configuredAtNames = currentUser.configured_ats.map(a => a.at_name);
 
         let atBrowserRunSets = [];
@@ -134,14 +140,14 @@ TestQueue.propTypes = {
     cycle: PropTypes.object,
     cycleId: PropTypes.number,
     testsForRuns: PropTypes.object,
-    users: PropTypes.array,
+    usersById: PropTypes.object,
     userId: PropTypes.number,
     dispatch: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {
     const { cyclesById, runsForCycle } = state.cycles;
-    const { users } = state.users;
+    const { usersById } = state.users;
     const userId = state.login.id;
     const cycleId = parseInt(ownProps.match.params.cycleId);
 
@@ -152,7 +158,7 @@ const mapStateToProps = (state, ownProps) => {
         testsForRuns = runsForCycle[cycleId];
     }
 
-    return { cycle, cycleId, testsForRuns, users, userId };
+    return { cycle, cycleId, testsForRuns, usersById, userId };
 };
 
 export default connect(mapStateToProps)(TestQueue);

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -1,9 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Table, Button } from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { getTestCycles, getRunsForUserAndCycle } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
 
@@ -33,7 +32,12 @@ class TestQueue extends Component {
 
     renderAtBrowserList(runIds) {
         const { userId, usersById, cycle } = this.props;
-        const { at_name, at_version, browser_name, browser_version } = cycle.runsById[runIds[0]];
+        const {
+            at_name,
+            at_version,
+            browser_name,
+            browser_version
+        } = cycle.runsById[runIds[0]];
 
         return (
             <div key={`${at_name}${browser_name}`}>
@@ -47,18 +51,21 @@ class TestQueue extends Component {
                             <th>Actions</th>
                         </tr>
                     </thead>
-                <tbody>{runIds.map(runId => (
-                    <TestQueueRun
-                      key={runId}
-                      runId={runId}
-                      apgExampleName={cycle.runsById[runId].apg_example_name}
-                      testers={cycle.runsById[runId].testers}
-                      cycleId={cycle.id}
-                      usersById={usersById}
-                      userId={userId}
-                    />
-                ))}
-                </tbody>
+                    <tbody>
+                        {runIds.map(runId => (
+                            <TestQueueRun
+                                key={runId}
+                                runId={runId}
+                                apgExampleName={
+                                    cycle.runsById[runId].apg_example_name
+                                }
+                                testers={cycle.runsById[runId].testers}
+                                cycleId={cycle.id}
+                                usersById={usersById}
+                                userId={userId}
+                            />
+                        ))}
+                    </tbody>
                 </Table>
             </div>
         );

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -1,10 +1,9 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { deleteUsersFromRun, saveUsersToRuns } from '../../actions/cycles';
-
 
 class TestQueueRow extends Component {
     constructor(props) {
@@ -24,7 +23,14 @@ class TestQueueRow extends Component {
     }
 
     render() {
-        const { cycleId, userId, usersById, runId, testers, apgExampleName } = this.props;
+        const {
+            cycleId,
+            userId,
+            usersById,
+            runId,
+            testers,
+            apgExampleName
+        } = this.props;
         let currentUserAssigned = testers.includes(userId);
 
         let userNames = testers.map(uid => {
@@ -45,15 +51,11 @@ class TestQueueRow extends Component {
         let assignOrUnassignButton;
         if (currentUserAssigned) {
             assignOrUnassignButton = (
-                <Button onClick={this.handleUnassignClick}>
-                  Unassign Me
-                </Button>
+                <Button onClick={this.handleUnassignClick}>Unassign Me</Button>
             );
         } else if (testers.length < 2) {
             assignOrUnassignButton = (
-                <Button onClick={this.handleAssignClick}>
-                  Assign Me
-                </Button>
+                <Button onClick={this.handleAssignClick}>Assign Me</Button>
             );
         }
 
@@ -75,7 +77,7 @@ TestQueueRow.propTypes = {
     testers: PropTypes.array,
     usersById: PropTypes.object,
     userId: PropTypes.number,
-    dispatch: PropTypes.func,
+    dispatch: PropTypes.func
 };
 
 export default connect()(TestQueueRow);

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -1,0 +1,81 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { deleteUsersFromRun, saveUsersToRuns } from '../../actions/cycles';
+
+
+class TestQueueRow extends Component {
+    constructor(props) {
+        super(props);
+        this.handleUnassignClick = this.handleUnassignClick.bind(this);
+        this.handleAssignClick = this.handleAssignClick.bind(this);
+    }
+
+    handleUnassignClick() {
+        const { dispatch, cycleId, userId, runId } = this.props;
+        dispatch(deleteUsersFromRun([userId], runId, cycleId));
+    }
+
+    handleAssignClick() {
+        const { dispatch, cycleId, userId, runId } = this.props;
+        dispatch(saveUsersToRuns([userId], [runId], cycleId));
+    }
+
+    render() {
+        const { cycleId, userId, usersById, runId, testers, apgExampleName } = this.props;
+        let currentUserAssigned = testers.includes(userId);
+
+        let userNames = testers.map(uid => {
+            return usersById[uid].fullname;
+        });
+
+        let designPatternLinkOrName;
+        if (currentUserAssigned) {
+            designPatternLinkOrName = (
+                <Link to={`/cycles/${cycleId}/run/${runId}`}>
+                    {apgExampleName}
+                </Link>
+            );
+        } else {
+            designPatternLinkOrName = apgExampleName;
+        }
+
+        let assignOrUnassignButton;
+        if (currentUserAssigned) {
+            assignOrUnassignButton = (
+                <Button onClick={this.handleUnassignClick}>
+                  Unassign Me
+                </Button>
+            );
+        } else if (testers.length < 2) {
+            assignOrUnassignButton = (
+                <Button onClick={this.handleAssignClick}>
+                  Assign Me
+                </Button>
+            );
+        }
+
+        return (
+            <tr key={runId}>
+                <td>{designPatternLinkOrName}</td>
+                <td>{userNames.join(', ')}</td>
+                <td>status</td>
+                <td>{assignOrUnassignButton}</td>
+            </tr>
+        );
+    }
+}
+
+TestQueueRow.propTypes = {
+    cycleId: PropTypes.number,
+    runId: PropTypes.number,
+    apgExampleName: PropTypes.string,
+    testers: PropTypes.array,
+    usersById: PropTypes.object,
+    userId: PropTypes.number,
+    dispatch: PropTypes.func,
+};
+
+export default connect()(TestQueueRow);

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -137,7 +137,7 @@ TestRun.propTypes = {
 
 const mapStateToProps = (state, ownProps) => {
     const { cyclesById, runsForCycle } = state.cycles;
-    const { users } = state.users;
+    const { usersById } = state.users;
     const userId = state.login.id;
     const cycleId = parseInt(ownProps.match.params.cycleId);
     const runId = parseInt(ownProps.match.params.runId);
@@ -151,7 +151,7 @@ const mapStateToProps = (state, ownProps) => {
         tests = runsForCycle[cycleId][runId].tests;
     }
 
-    return { cycle, cycleId, run, tests, users, userId };
+    return { cycle, cycleId, run, tests, usersById, userId };
 };
 
 export default connect(mapStateToProps)(TestRun);

--- a/client/components/UserSettings/index.jsx
+++ b/client/components/UserSettings/index.jsx
@@ -73,13 +73,12 @@ class UserSettings extends Component {
     }
 
     onSubmit(event) {
-        const { dispatch, username, email, fullname, ats } = this.props;
-        let currentUser = { username, email, fullname };
+        const { dispatch, ats, userId } = this.props;
         const selectedAts = Object.entries(this.state)
             .filter(atEntry => atEntry[1].checked)
             .map(atEntry => atEntry[0])
             .map(atName => ats.filter(at => at.name === atName).shift());
-        dispatch(handleSetUserAts(currentUser, selectedAts));
+        dispatch(handleSetUserAts(userId, selectedAts));
         event.preventDefault();
     }
 
@@ -140,12 +139,12 @@ UserSettings.propTypes = {
 };
 
 const mapStateToProps = state => {
-    const { isLoggedIn, username, fullname, email } = state.login;
+    const { isLoggedIn, username, fullname, email, id } = state.login;
+    const { usersById } = state.users;
+
     let currentUserAts = [];
-    if (username && state.users.users.length > 0) {
-        currentUserAts = state.users.users.filter(
-            user => user.username === state.login.username
-        )[0].configured_ats;
+    if (username && usersById[id]) {
+        currentUserAts = usersById[id].configured_ats;
     }
 
     return {
@@ -154,6 +153,7 @@ const mapStateToProps = state => {
         fullname,
         email,
         ats: state.ats,
+        userId: id,
         currentUserAts
     };
 };

--- a/client/components/UserSettings/index.jsx
+++ b/client/components/UserSettings/index.jsx
@@ -133,6 +133,7 @@ UserSettings.propTypes = {
     fullname: PropTypes.string,
     username: PropTypes.string,
     email: PropTypes.string,
+    userId: PropTypes.number,
     ats: PropTypes.array,
     dispatch: PropTypes.func,
     currentUserAts: PropTypes.array

--- a/client/reducers/users.js
+++ b/client/reducers/users.js
@@ -1,50 +1,46 @@
 import { GET_USERS, SET_USER_ATS } from '../actions/types';
 
-// TODO: Change this into a object key'd by user id?
 const initialState = {
-    users: []
+    usersById: {}
 };
 
 export default (state = initialState, action) => {
     switch (action.type) {
         case GET_USERS: {
             const users = action.payload;
-            return Object.assign({}, state, {
-                users
+            const usersById = {};
+            users.map(u => {
+                usersById[u.id] = u;
             });
-        }
-        case SET_USER_ATS: {
-            let { user, ats } = action.payload;
-            let users = state.users.slice();
-            let findUser = state.users.find(
-                stateUser => stateUser.username === user.username
-            );
-            if (findUser) {
-                let currentUser = findUser;
-                let configuredUserAts = currentUser.configured_ats;
-                let updatedAts = [];
-
-                for (let at of ats) {
-                    let atFound = configuredUserAts.find(
-                        configuredAt =>
-                            configuredAt.at_name_id === at.at_name_id
-                    );
-                    if (atFound) {
-                        atFound.active = at.active;
-                        updatedAts.push(atFound);
-                    } else {
-                        updatedAts.push(at);
-                    }
-                }
-
-                let currentUserIdx = users.findIndex(
-                    user => user.id === currentUser.id
-                );
-                users[currentUserIdx].configured_ats = updatedAts;
-            }
             return {
                 ...state,
-                users: [...users]
+                usersById
+            };
+        }
+        case SET_USER_ATS: {
+            let { userId, ats } = action.payload;
+            let updatedUser = { ...state.usersById[userId] };
+
+            let updatedAts = [];
+            for (let at of updatedUser.configured_ats) {
+                let atFound = configuredUserAts.find(
+                    configuredAt => configuredAt.at_name_id === at.at_name_id
+                );
+                if (atFound) {
+                    atFound.active = at.active;
+                    updatedAts.push(atFound);
+                } else {
+                    updatedAts.push(at);
+                }
+            }
+            updatedUser.configured_ats = updatedAts;
+
+            return {
+                ...state,
+                usersById: {
+                    ...state.usersById,
+                    [userId]: updatedUser
+                }
             };
         }
         default:

--- a/client/reducers/users.js
+++ b/client/reducers/users.js
@@ -19,10 +19,11 @@ export default (state = initialState, action) => {
         }
         case SET_USER_ATS: {
             let { userId, ats } = action.payload;
-            let updatedUser = { ...state.usersById[userId] };
+            let updateUser = { ...state.usersById[userId] };
+            let configuredUserAts = updateUser.configured_ats;
 
             let updatedAts = [];
-            for (let at of updatedUser.configured_ats) {
+            for (let at of ats) {
                 let atFound = configuredUserAts.find(
                     configuredAt => configuredAt.at_name_id === at.at_name_id
                 );
@@ -33,13 +34,13 @@ export default (state = initialState, action) => {
                     updatedAts.push(at);
                 }
             }
-            updatedUser.configured_ats = updatedAts;
+            updateUser.configured_ats = updatedAts;
 
             return {
                 ...state,
                 usersById: {
                     ...state.usersById,
-                    [userId]: updatedUser
+                    [userId]: updateUser
                 }
             };
         }

--- a/client/reducers/users.js
+++ b/client/reducers/users.js
@@ -8,10 +8,10 @@ export default (state = initialState, action) => {
     switch (action.type) {
         case GET_USERS: {
             const users = action.payload;
-            const usersById = {};
-            users.map(u => {
-                usersById[u.id] = u;
-            });
+            const usersById = users.reduce((accum, user) => {
+                accum[user.id] = user;
+                return accum;
+            }, {});
             return {
                 ...state,
                 usersById

--- a/client/tests/integration.test.js
+++ b/client/tests/integration.test.js
@@ -31,7 +31,7 @@ describe('login actions dispatchers', () => {
             },
             ats: [],
             users: {
-                users: []
+                usersById: {}
             }
         };
 
@@ -65,7 +65,7 @@ describe('login actions dispatchers', () => {
             },
             ats: [],
             users: {
-                users: []
+                usersById: {}
             }
         };
 
@@ -105,7 +105,7 @@ describe('ats action dispatchers', () => {
                 names: ['JAWS', 'NVDA', 'VoiceOver']
             },
             users: {
-                users: []
+                usersById: {}
             }
         };
 
@@ -139,8 +139,8 @@ describe('users action dispatchers', () => {
             },
             ats: [],
             users: {
-                users: [
-                    {
+                usersById: {
+                    1: {
                         id: 1,
                         username: 'foobar',
                         configured_ats: [
@@ -154,7 +154,7 @@ describe('users action dispatchers', () => {
                             }
                         ]
                     }
-                ]
+                }
             }
         };
         moxios.install();

--- a/client/tests/integration.test.js
+++ b/client/tests/integration.test.js
@@ -198,11 +198,10 @@ describe('users action dispatchers', () => {
                 ]
             });
         });
-
         await store.dispatch(
             handleSetUserAts(
-                { username: 'foobar', id: 1 },
-                expectedState.users.users[0].configured_ats
+                1,
+                expectedState.users.usersById[1].configured_ats
             )
         );
         const newState = store.getState();

--- a/client/tests/reducers.test.js
+++ b/client/tests/reducers.test.js
@@ -55,11 +55,11 @@ describe('ats reducer tests', () => {
 describe('users reducer tests', () => {
     test('returns default initial state when no action is passed', () => {
         const newState = usersReducer(undefined, {});
-        expect(newState).toEqual({ users: [] });
+        expect(newState).toEqual({ usersById: {} });
     });
     test('returns object upon receiving an action of type `SET_USER_ATS`', () => {
         const apiPayload = {
-            user: { username: 'foobar' },
+            userId: 1,
             ats: [
                 { at_name_id: 1, active: true },
                 { at_name_id: 2, active: true }
@@ -67,13 +67,13 @@ describe('users reducer tests', () => {
         };
         const newState = usersReducer(
             {
-                users: [
-                    {
+                usersById: {
+                    1: {
                         id: 1,
                         username: 'foobar',
                         configured_ats: [{ at_name_id: 1, active: false }]
                     }
-                ]
+                }
             },
             {
                 type: SET_USER_ATS,
@@ -81,8 +81,8 @@ describe('users reducer tests', () => {
             }
         );
         expect(newState).toEqual({
-            users: [
-                {
+            usersById: {
+                1: {
                     id: 1,
                     username: 'foobar',
                     configured_ats: [
@@ -90,7 +90,7 @@ describe('users reducer tests', () => {
                         { at_name_id: 2, active: true }
                     ]
                 }
-            ]
+            }
         });
     });
 });

--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -61,7 +61,6 @@ async function getAllTesters(req, res) {
 
 async function setUserAts(req, res) {
     const { ats, userId } = req.body;
-    console.log('REQ.BODY IN CONTROLLER', req.body);
     try {
         const response = await UsersService.saveUserAts({ userId, ats });
         res.status(200).json(response);

--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -60,9 +60,10 @@ async function getAllTesters(req, res) {
 }
 
 async function setUserAts(req, res) {
-    const { ats, user } = req.body;
+    const { ats, userId } = req.body;
+    console.log('REQ.BODY IN CONTROLLER', req.body);
     try {
-        const response = await UsersService.saveUserAts({ user, ats });
+        const response = await UsersService.saveUserAts({ userId, ats });
         res.status(200).json(response);
     } catch (error) {
         res.status(400);

--- a/server/services/UsersService.js
+++ b/server/services/UsersService.js
@@ -353,9 +353,9 @@ async function getUserAts(options) {
 }
 
 async function saveUserAts(options) {
-    const { user, ats } = options;
-    let { id: user_id } = await getUser(user);
-    const existingUserAtsIds = (await getUserAts(user_id)).map(
+    console.log('OPTIONS IN USERSSERVICES', options);
+    const { userId, ats } = options;
+    const existingUserAtsIds = (await getUserAts(userId)).map(
         userAt => userAt.dataValues.at_name_id
     );
     const userAtsInactive = existingUserAtsIds.filter(
@@ -377,7 +377,11 @@ async function saveUserAts(options) {
                 { where: { at_name_id } }
             );
             if (inactiveUserAt.find(inactiveUserAt => inactiveUserAt === 1)) {
-                savedUserAts.push({ at_name_id, user_id, active: false });
+                savedUserAts.push({
+                    at_name_id,
+                    user_id: userId,
+                    active: false
+                });
             }
         } catch (error) {
             console.error(`Error: ${error}`);
@@ -389,7 +393,7 @@ async function saveUserAts(options) {
     try {
         let createdUserAt = await UserToAt.bulkCreate(
             userAtsActiveCreate.map(({ id: at_name_id }) => ({
-                user_id,
+                user_id: userId,
                 at_name_id,
                 active: true
             }))
@@ -410,7 +414,11 @@ async function saveUserAts(options) {
                 { where: { at_name_id: at.id } }
             );
             if (activeUserAt.find(activeUserAt => activeUserAt === 1)) {
-                savedUserAts.push({ at_name_id: at.id, user_id, active: true });
+                savedUserAts.push({
+                    at_name_id: at.id,
+                    user_id: userId,
+                    active: true
+                });
             }
         } catch (error) {
             console.error(`Error: ${error}`);

--- a/server/services/UsersService.js
+++ b/server/services/UsersService.js
@@ -353,8 +353,8 @@ async function getUserAts(options) {
 }
 
 async function saveUserAts(options) {
-    console.log('OPTIONS IN USERSSERVICES', options);
     const { userId, ats } = options;
+
     const existingUserAtsIds = (await getUserAts(userId)).map(
         userAt => userAt.dataValues.at_name_id
     );
@@ -372,17 +372,15 @@ async function saveUserAts(options) {
     // these rows already exist in the database
     for (let at_name_id of userAtsInactive) {
         try {
-            let inactiveUserAt = await UserToAt.update(
+            await UserToAt.update(
                 { active: false },
-                { where: { at_name_id } }
+                { where: { at_name_id, user_id: userId } }
             );
-            if (inactiveUserAt.find(inactiveUserAt => inactiveUserAt === 1)) {
-                savedUserAts.push({
-                    at_name_id,
-                    user_id: userId,
-                    active: false
-                });
-            }
+            savedUserAts.push({
+                at_name_id,
+                user_id: userId,
+                active: false
+            });
         } catch (error) {
             console.error(`Error: ${error}`);
             throw error;
@@ -409,17 +407,15 @@ async function saveUserAts(options) {
     // these rows also exist in the database
     for (let at of userAtsActiveUpdate) {
         try {
-            let activeUserAt = await UserToAt.update(
+            await UserToAt.update(
                 { active: true },
-                { where: { at_name_id: at.id } }
+                { where: { at_name_id: at.id, user_id: userId } }
             );
-            if (activeUserAt.find(activeUserAt => activeUserAt === 1)) {
-                savedUserAts.push({
-                    at_name_id: at.id,
-                    user_id: userId,
-                    active: true
-                });
-            }
+            savedUserAts.push({
+                at_name_id: at.id,
+                user_id: userId,
+                active: true
+            });
         } catch (error) {
             console.error(`Error: ${error}`);
             throw error;


### PR DESCRIPTION
Hey Erika, this PR does three things:
1. Makes users key'd by ID. This caused me to changes some of the user setting logic, because it was all based on username before. Also, it led me to find and fix that bug where sometimes all the ATs disappear on the user setting page! :)
2. Adds ability to assign and unassign yourself from runs in the user queue