### PR TITLE
Add popups for the "save and exit", "save and next test" and "skip to next test" buttons

### DIFF
--- a/client/components/App/index.jsx
+++ b/client/components/App/index.jsx
@@ -78,9 +78,9 @@ class App extends Component {
                         </Navbar.Collapse>
                     </Navbar>
                 </Container>
-                <main>
+                <Container as="main" fluid>
                     {renderRoutes(route.routes)}
-                </main>
+                </Container>
             </Fragment>
         );
     }

--- a/client/components/ConfigureRunsForExample/index.jsx
+++ b/client/components/ConfigureRunsForExample/index.jsx
@@ -85,7 +85,7 @@ class ConfigureRunsForExample extends Component {
     }
 
     render() {
-        const { example, usersById, testersByRunId, runs } = this.props;
+        const { example, usersById, testersByRunId, runs = [] } = this.props;
 
         runs.sort(function(a, b) {
             if (a.at_id === b.at_id) {

--- a/client/components/ConfigureTechnologyRow/index.jsx
+++ b/client/components/ConfigureTechnologyRow/index.jsx
@@ -72,7 +72,12 @@ class ConfigureTechnologyRow extends Component {
     }
 
     render() {
-        const { availableBrowsers, availableAts, runTechnologies, index } = this.props;
+        const {
+            availableBrowsers,
+            availableAts,
+            runTechnologies,
+            index
+        } = this.props;
 
         return (
             <Row>

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -54,11 +54,21 @@ class TestQueueRow extends Component {
         let assignOrUnassignButton;
         if (currentUserAssigned) {
             assignOrUnassignButton = (
-                <Button onClick={this.handleUnassignClick} aria-label={`Unassign me from the test run ${testrun}`}>Unassign Me</Button>
+                <Button
+                    onClick={this.handleUnassignClick}
+                    aria-label={`Unassign me from the test run ${testrun}`}
+                >
+                    Unassign Me
+                </Button>
             );
         } else if (testers.length < 2) {
             assignOrUnassignButton = (
-                <Button onClick={this.handleAssignClick} aria-label={`Assign me to the test run ${testrun}`}>Assign Me</Button>
+                <Button
+                    onClick={this.handleAssignClick}
+                    aria-label={`Assign me to the test run ${testrun}`}
+                >
+                    Assign Me
+                </Button>
             );
         }
 

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import './TestRun.css';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
-import { Container, Row, Col, Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import {
@@ -28,9 +27,15 @@ class TestRun extends Component {
         this.handleNextTestClick = this.handleNextTestClick.bind(this);
         this.handleSaveResultClick = this.handleSaveResultClick.bind(this);
 
-        this.handleCantSaveResultModalClose = this.handleCantSaveResultModalClose.bind(this);
-        this.handleConfirmSkipModalClose = this.handleConfirmSkipModalClose.bind(this);
-        this.handleConfirmSkipModalContinue = this.handleConfirmSkipModalContinue.bind(this);
+        this.handleCantSaveResultModalClose = this.handleCantSaveResultModalClose.bind(
+            this
+        );
+        this.handleConfirmSkipModalClose = this.handleConfirmSkipModalClose.bind(
+            this
+        );
+        this.handleConfirmSkipModalContinue = this.handleConfirmSkipModalContinue.bind(
+            this
+        );
 
         this.testIframe = React.createRef();
     }
@@ -99,7 +104,9 @@ class TestRun extends Component {
         try {
             result = JSON.parse(resultsEl.innerText);
         } catch (error) {
-            console.error("Cannot save tests do to malformed information from test file.");
+            console.error(
+                'Cannot save tests do to malformed information from test file.'
+            );
             throw error;
         }
 
@@ -116,8 +123,7 @@ class TestRun extends Component {
 
         if (exit) {
             history.push(`/test-queue/${cycleId}`);
-        }
-        else {
+        } else {
             this.setState(prevState => {
                 return {
                     ...this.nextTestState(prevState),
@@ -144,33 +150,57 @@ class TestRun extends Component {
     }
 
     renderModals() {
-        return(
+        return (
             <React.Fragment>
-              <Modal show={this.state.showCantSaveResultModal} onHide={this.handleCantSaveResultModalClose} centered animation={false}>
-                <Modal.Header closeButton>
-                  <Modal.Title>Cannot Save Results</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>Test is not complete, we cannot save incomplete and unreviewd tests. Please fill in the entire tests and click "review results", then you can save.</Modal.Body>
-                <Modal.Footer>
-                  <Button variant="secondary" onClick={this.handleCantSaveResultModalClose}>
-                    Close
-                  </Button>
-                </Modal.Footer>
-              </Modal>
-              <Modal show={this.state.showConfirmSkipModal} onHide={this.handleConfirmSkipModalClose} centered animation={false}>
-                <Modal.Header closeButton>
-                  <Modal.Title>Skip to Next Tests</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>{`Are you sure you want to continue? Your progress on test ${this.state.currentTestIndex} won't be saved.`}</Modal.Body>
-                <Modal.Footer>
-                  <Button variant="secondary" onClick={this.handleConfirmSkipModalClose}>
-                    Cancel
-                  </Button>
-                  <Button variant="secondary" onClick={this.handleConfirmSkipModalContinue}>
-                    Continue
-                  </Button>
-                </Modal.Footer>
-              </Modal>
+                <Modal
+                    show={this.state.showCantSaveResultModal}
+                    onHide={this.handleCantSaveResultModalClose}
+                    centered
+                    animation={false}
+                >
+                    <Modal.Header closeButton>
+                        <Modal.Title>Cannot Save Results</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        Test is not complete, we cannot save incomplete and
+                        unreviewd tests. Please fill in the entire tests and
+                        click the button <b>review results</b>, then you can
+                        save.
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            variant="secondary"
+                            onClick={this.handleCantSaveResultModalClose}
+                        >
+                            Close
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
+                <Modal
+                    show={this.state.showConfirmSkipModal}
+                    onHide={this.handleConfirmSkipModalClose}
+                    centered
+                    animation={false}
+                >
+                    <Modal.Header closeButton>
+                        <Modal.Title>Skip to Next Tests</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>{`Are you sure you want to continue? Your progress on test ${this.state.currentTestIndex} won't be saved.`}</Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            variant="secondary"
+                            onClick={this.handleConfirmSkipModalClose}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="secondary"
+                            onClick={this.handleConfirmSkipModalContinue}
+                        >
+                            Continue
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
             </React.Fragment>
         );
     }
@@ -228,13 +258,17 @@ class TestRun extends Component {
                             <Button variant="primary">Previous Test</Button>
                             <Button
                                 variant="primary"
-                                onClick={() => this.handleSaveResultClick({exit: true})}
+                                onClick={() =>
+                                    this.handleSaveResultClick({ exit: true })
+                                }
                             >
                                 Save results and exit
                             </Button>
                             <Button
                                 variant="primary"
-                                onClick={() => this.handleSaveResultClick({exit: false})}
+                                onClick={() =>
+                                    this.handleSaveResultClick({ exit: false })
+                                }
                             >
                                 Save results and go to next test
                             </Button>
@@ -246,7 +280,6 @@ class TestRun extends Component {
                             >
                                 Skip to next test
                             </Button>
-
                         </React.Fragment>
                     );
                 } else {

--- a/client/tests/UserSettings.test.jsx
+++ b/client/tests/UserSettings.test.jsx
@@ -40,7 +40,12 @@ describe('render', () => {
         let wrapper;
         beforeEach(() => {
             const initialState = {
-                login: { isLoggedIn: true, loadedUserData: true, username: 'foobar', name: 'Foo Bar' }
+                login: {
+                    isLoggedIn: true,
+                    loadedUserData: true,
+                    username: 'foobar',
+                    name: 'Foo Bar'
+                }
             };
             wrapper = setup(initialState);
         });

--- a/client/tests/reducers.test.js
+++ b/client/tests/reducers.test.js
@@ -17,7 +17,11 @@ describe('login reducer tests', () => {
             type: CHECK_LOGGED_IN,
             payload: apiPayload
         });
-        expect(newState).toEqual({ isLoggedIn: true, loadedUserData: true, ...apiPayload });
+        expect(newState).toEqual({
+            isLoggedIn: true,
+            loadedUserData: true,
+            ...apiPayload
+        });
     });
     test('returns object without username and name and isLoggedIn false with `LOG_OUT` type', () => {
         const apiPayload = {


### PR DESCRIPTION
To test:
Start a test run and don't complete the first test:
- [x] click the "save and exit" button, see that a modal appears and it won't let you save and exit
- [x] click the "save and next test" button, see that a modal appears and it won't let you save and exit
- [x] click "skip and go to next test", see that a modal appears, make sure all the buttons do what you would expect

Complete the first test:
- [x] click the "save and exit" button, and you will be redirected to the tester queue for that cycle
- [x] click the "save and next test" button, and you will see the next test