### PR TITLE
View results

### DIFF
--- a/client/components/DisplayTest/DisplayTest.css
+++ b/client/components/DisplayTest/DisplayTest.css
@@ -1,0 +1,13 @@
+#test-iframe {
+    width: 80vw;
+    height: 65vh;
+}
+
+.testrun__button--right {
+    position: absolute;
+    right: 0;
+}
+
+.testrun__button-toolbar--margin {
+    margin: 1em 0;
+}

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -106,10 +106,7 @@ class DisplayTest extends Component {
                 throw error;
             }
 
-            saveResultFromTest({
-                test_id: test.id,
-                result
-            });
+            saveResultFromTest(result);
         }
 
         // Save was successful

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -116,33 +116,31 @@ class DisplayTest extends Component {
     renderModal() {
         let { testIndex } = this.props;
         return (
-            <Fragment>
-                <Modal
-                    show={this.state.showConfirmLeaveTestModal}
-                    onHide={this.handleCloseLeaveTestModal}
-                    centered
-                    animation={false}
-                >
-                    <Modal.Header closeButton>
-                        <Modal.Title>Leave Test</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>{`Are you sure you want to leave this test? Because the test has not been completed in full, your progress on test ${testIndex} won't be saved.`}</Modal.Body>
-                    <Modal.Footer>
-                        <Button
-                            variant="secondary"
-                            onClick={this.handleCloseLeaveTestModal}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            variant="secondary"
-                            onClick={this.handleConfirmLeaveTest}
-                        >
-                            Continue
-                        </Button>
-                    </Modal.Footer>
-                </Modal>
-            </Fragment>
+            <Modal
+                show={this.state.showConfirmLeaveTestModal}
+                onHide={this.handleCloseLeaveTestModal}
+                centered
+                animation={false}
+            >
+                <Modal.Header closeButton>
+                    <Modal.Title>Leave Test</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>{`Are you sure you want to leave this test? Because the test has not been completed in full, your progress on test ${testIndex} won't be saved.`}</Modal.Body>
+                <Modal.Footer>
+                    <Button
+                        variant="secondary"
+                        onClick={this.handleCloseLeaveTestModal}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={this.handleConfirmLeaveTest}
+                    >
+                        Continue
+                    </Button>
+                </Modal.Footer>
+            </Modal>
         );
     }
 

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -7,7 +7,6 @@ import {
     ButtonGroup,
     ButtonToolbar,
     Col,
-    Container,
     Modal,
     Row
 } from 'react-bootstrap';
@@ -29,9 +28,7 @@ class DisplayTest extends Component {
         this.handleCloseLeaveTestModal = this.handleCloseLeaveTestModal.bind(
             this
         );
-        this.handleConfirmLeaveTest = this.handleConfirmLeaveTest.bind(
-            this
-        );
+        this.handleConfirmLeaveTest = this.handleConfirmLeaveTest.bind(this);
 
         this.testIframe = React.createRef();
     }
@@ -50,8 +47,12 @@ class DisplayTest extends Component {
     }
 
     performButtonAction() {
-        console.log(this.props);
-        const { cycleId, history, displayNextTest, displayPreviousTest } = this.props;
+        const {
+            cycleId,
+            history,
+            displayNextTest,
+            displayPreviousTest
+        } = this.props;
         if (this.buttonAction === 'exitAfterConfirm') {
             history.push(`/test-queue/${cycleId}`);
         }
@@ -79,7 +80,7 @@ class DisplayTest extends Component {
         this.trySaving();
     }
 
-    trySaving(options) {
+    trySaving() {
         const { saveResultFromTest, test } = this.props;
 
         // Only to to save if results don't exist
@@ -153,50 +154,41 @@ class DisplayTest extends Component {
 
         const testHasResult = test.result ? true : false;
 
-        let heading = null;
-        let content = null;
         let testContent = null;
         let menuUnderContent = null;
         let menuRightOContent = null;
 
         menuUnderContent = (
             <ButtonToolbar className="testrun__button-toolbar--margin">
-                {testIndex !== 1 &&
-                     <Button variant="primary"
-                             onClick={this.handlePreviousTestClick}
-                     >
-                       Previous Test
-                     </Button>
-                }
-                  <Button
+                {testIndex !== 1 && (
+                    <Button
+                        variant="primary"
+                        onClick={this.handlePreviousTestClick}
+                    >
+                        Previous Test
+                    </Button>
+                )}
+                <Button
                     className="testrun__button--right"
-                      variant="primary"
-                      onClick={this.handleNextTestClick}
-                  >
-                      Next Test
-
-                  </Button>
+                    variant="primary"
+                    onClick={this.handleNextTestClick}
+                >
+                    Next Test
+                </Button>
             </ButtonToolbar>
         );
         menuRightOContent = (
             <ButtonGroup vertical>
                 <Button variant="primary">Raise an issue</Button>
                 <Button variant="primary">Re-do Test</Button>
-                <Button
-                  variant="primary"
-                  onClick={this.handleCloseRunClick}
-                >
-                  {testHasResult ? 'Close' : 'Save and Close'}
+                <Button variant="primary" onClick={this.handleCloseRunClick}>
+                    {testHasResult ? 'Close' : 'Save and Close'}
                 </Button>
             </ButtonGroup>
         );
 
         if (testHasResult) {
-            testContent = (
-                <TestResult
-                  testResult={test.result}
-                />
-            );
+            testContent = <TestResult testResult={test.result} />;
         } else {
             testContent = (
                 <iframe
@@ -207,17 +199,16 @@ class DisplayTest extends Component {
             );
         }
 
-
         let modals = this.renderModal();
 
         return (
             <Fragment>
-              <Col md={9}>
-                <Row>{testContent}</Row>
-                <Row>{menuUnderContent}</Row>
-              </Col>
-              <Col md={3}>{menuRightOContent}</Col>
-              {modals}
+                <Col md={9}>
+                    <Row>{testContent}</Row>
+                    <Row>{menuUnderContent}</Row>
+                </Col>
+                <Col md={3}>{menuRightOContent}</Col>
+                {modals}
             </Fragment>
         );
     }

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -1,0 +1,239 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import './DisplayTest.css';
+import { withRouter } from 'react-router-dom';
+import {
+    Button,
+    ButtonGroup,
+    ButtonToolbar,
+    Col,
+    Container,
+    Modal,
+    Row
+} from 'react-bootstrap';
+import TestResult from '@components/TestResult';
+
+class DisplayTest extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showConfirmLeaveTestModal: false
+        };
+
+        this.buttonAction = '';
+
+        this.handleNextTestClick = this.handleNextTestClick.bind(this);
+        this.handlePreviousTestClick = this.handlePreviousTestClick.bind(this);
+        this.handleCloseRunClick = this.handleCloseRunClick.bind(this);
+        this.handleCloseLeaveTestModal = this.handleCloseLeaveTestModal.bind(
+            this
+        );
+        this.handleConfirmLeaveTest = this.handleConfirmLeaveTest.bind(
+            this
+        );
+
+        this.testIframe = React.createRef();
+    }
+
+    handleCloseLeaveTestModal() {
+        this.setState({
+            showConfirmLeaveTestModal: false
+        });
+    }
+
+    handleConfirmLeaveTest() {
+        this.setState({
+            showConfirmLeaveTestModal: false
+        });
+        this.performButtonAction();
+    }
+
+    performButtonAction() {
+        console.log(this.props);
+        const { cycleId, history, displayNextTest, displayPreviousTest } = this.props;
+        if (this.buttonAction === 'exitAfterConfirm') {
+            history.push(`/test-queue/${cycleId}`);
+        }
+        if (this.buttonAction === 'goToNextTest') {
+            displayNextTest();
+        }
+        if (this.buttonAction === 'goToPreviousTest') {
+            displayPreviousTest();
+        }
+        this.buttonAction = '';
+    }
+
+    handleNextTestClick() {
+        this.buttonAction = 'goToNextTest';
+        this.trySaving();
+    }
+
+    handlePreviousTestClick() {
+        this.buttonAction = 'goToPreviousTest';
+        this.trySaving();
+    }
+
+    handleCloseRunClick() {
+        this.buttonAction = 'exitAfterConfirm';
+        this.trySaving();
+    }
+
+    trySaving(options) {
+        const { saveResultFromTest, test } = this.props;
+
+        // Only to to save if results don't exist
+        if (!test.result) {
+            let resultsEl = this.testIframe.current.contentDocument.querySelector(
+                '#__ariaatharness__results__'
+            );
+
+            if (!resultsEl) {
+                this.setState({
+                    showConfirmLeaveTestModal: true
+                });
+                return;
+            }
+
+            let result;
+            try {
+                result = JSON.parse(resultsEl.innerText);
+            } catch (error) {
+                console.error(
+                    'Cannot save tests do to malformed information from test file.'
+                );
+                throw error;
+            }
+
+            saveResultFromTest({
+                test_id: test.id,
+                result
+            });
+        }
+
+        // Save was successful
+        this.performButtonAction();
+    }
+
+    renderModal() {
+        let { testIndex } = this.props;
+        return (
+            <Fragment>
+                <Modal
+                    show={this.state.showConfirmLeaveTestModal}
+                    onHide={this.handleCloseLeaveTestModal}
+                    centered
+                    animation={false}
+                >
+                    <Modal.Header closeButton>
+                        <Modal.Title>Leave Test</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>{`Are you sure you want to leave this test? Because the test has not been completed in full, your progress on test ${testIndex} won't be saved.`}</Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            variant="secondary"
+                            onClick={this.handleCloseLeaveTestModal}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="secondary"
+                            onClick={this.handleConfirmLeaveTest}
+                        >
+                            Continue
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
+            </Fragment>
+        );
+    }
+
+    render() {
+        const { test, git_hash, at_key, testIndex } = this.props;
+
+        const testHasResult = test.result ? true : false;
+
+        let heading = null;
+        let content = null;
+        let testContent = null;
+        let menuUnderContent = null;
+        let menuRightOContent = null;
+
+        menuUnderContent = (
+            <ButtonToolbar className="testrun__button-toolbar--margin">
+                {testIndex !== 1 &&
+                     <Button variant="primary"
+                             onClick={this.handlePreviousTestClick}
+                     >
+                       Previous Test
+                     </Button>
+                }
+                  <Button
+                    className="testrun__button--right"
+                      variant="primary"
+                      onClick={this.handleNextTestClick}
+                  >
+                      Next Test
+
+                  </Button>
+            </ButtonToolbar>
+        );
+        menuRightOContent = (
+            <ButtonGroup vertical>
+                <Button variant="primary">Raise an issue</Button>
+                <Button variant="primary">Re-do Test</Button>
+                <Button
+                  variant="primary"
+                  onClick={this.handleCloseRunClick}
+                >
+                  {testHasResult ? 'Close' : 'Save and Close'}
+                </Button>
+            </ButtonGroup>
+        );
+
+        if (testHasResult) {
+            testContent = (
+                <TestResult
+                  testResult={test.result}
+                />
+            );
+        } else {
+            testContent = (
+                <iframe
+                    src={`/aria-at/${git_hash}/${test.file}?at=${at_key}`}
+                    id="test-iframe"
+                    ref={this.testIframe}
+                ></iframe>
+            );
+        }
+
+
+        let modals = this.renderModal();
+
+        return (
+            <Fragment>
+              <Col md={9}>
+                <Row>{testContent}</Row>
+                <Row>{menuUnderContent}</Row>
+              </Col>
+              <Col md={3}>{menuRightOContent}</Col>
+              {modals}
+            </Fragment>
+        );
+    }
+}
+
+DisplayTest.propTypes = {
+    dispatch: PropTypes.func,
+    test: PropTypes.object,
+    testIndex: PropTypes.number,
+    git_hash: PropTypes.string,
+    at_key: PropTypes.string,
+    cycleId: PropTypes.number,
+    history: PropTypes.object,
+    displayNextTest: PropTypes.func,
+    displayPreviousTest: PropTypes.func,
+    saveResultFromTest: PropTypes.func
+};
+
+export default withRouter(DisplayTest);

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -1,0 +1,89 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Table } from 'react-bootstrap';
+
+class TestResult extends Component {
+    renderPassingAssertions(assertions) {
+        if (assertions.length === 0) {
+            return (
+                <ul><li>No passing assertions.</li></ul>
+            );
+        }
+        return (
+            <ul>
+              {assertions.map((a, index) => <li key={index}>{`${a.pass}: ${a.assertion}`}</li>)}
+            </ul>
+        );
+    }
+
+    renderFailingAssertions(assertions) {
+        if (assertions.length === 0) {
+            return (
+                <ul><li>No failing assertions.</li></ul>
+            );
+        }
+        return (
+            <ul>
+              {assertions.map((a, index) => <li key={index}>{`${a.fail}: ${a.assertion}`}</li>)}
+            </ul>
+        );
+    }
+
+    renderUnexpected(unexpecteds) {
+        if (unexpecteds.length === 0) {
+            return (
+                <ul><li>No unexpected behavior.</li></ul>
+            );
+        }
+        return (
+            <ul>
+              {unexpecteds.map((u, index) => <li key={index}>{u}</li>)}
+            </ul>
+        );
+
+    }
+
+    render() {
+        const { testResult } = this.props;
+
+        return (
+            <Fragment>
+                <h2>Test Cycles</h2>
+                <Table striped bordered hover>
+                    <thead>
+                        <tr>
+                            <th>Command</th>
+                            <th>Support</th>
+                            <th>Details</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {testResult.result.details.commands.map((command, index) => {
+                            let passing = command.assertions.filter(a => a.pass !== undefined);
+                            let failing = command.assertions.filter(a => a.fail !== undefined);
+
+                            return (
+                                <tr key={index}>
+                                    <td>{command.command}</td>
+                                    <td>{command.support}</td>
+                                    <td>
+                                      <p>Output: {command.output}</p>
+                                      <p>Passing Assertions:</p>{this.renderPassingAssertions(passing)}
+                                      <p>Failing Assertions:</p> {this.renderFailingAssertions(failing)}
+                                      <p>Unexpected Behaviors:</p> {this.renderUnexpected(command.unexpected_behaviors)}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </Table>
+            </Fragment>
+        );
+    }
+}
+
+TestResult.propTypes = {
+    testReulst: PropTypes.object
+};
+
+export default TestResult;

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -48,7 +48,6 @@ class TestResult extends Component {
 
         return (
             <Fragment>
-                <h2>Test Cycles</h2>
                 <Table striped bordered hover>
                     <thead>
                         <tr>

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -6,12 +6,16 @@ class TestResult extends Component {
     renderPassingAssertions(assertions) {
         if (assertions.length === 0) {
             return (
-                <ul><li>No passing assertions.</li></ul>
+                <ul>
+                    <li>No passing assertions.</li>
+                </ul>
             );
         }
         return (
             <ul>
-              {assertions.map((a, index) => <li key={index}>{`${a.pass}: ${a.assertion}`}</li>)}
+                {assertions.map((a, index) => (
+                    <li key={index}>{`${a.pass}: ${a.assertion}`}</li>
+                ))}
             </ul>
         );
     }
@@ -19,12 +23,16 @@ class TestResult extends Component {
     renderFailingAssertions(assertions) {
         if (assertions.length === 0) {
             return (
-                <ul><li>No failing assertions.</li></ul>
+                <ul>
+                    <li>No failing assertions.</li>
+                </ul>
             );
         }
         return (
             <ul>
-              {assertions.map((a, index) => <li key={index}>{`${a.fail}: ${a.assertion}`}</li>)}
+                {assertions.map((a, index) => (
+                    <li key={index}>{`${a.fail}: ${a.assertion}`}</li>
+                ))}
             </ul>
         );
     }
@@ -32,15 +40,18 @@ class TestResult extends Component {
     renderUnexpected(unexpecteds) {
         if (unexpecteds.length === 0) {
             return (
-                <ul><li>No unexpected behavior.</li></ul>
+                <ul>
+                    <li>No unexpected behavior.</li>
+                </ul>
             );
         }
         return (
             <ul>
-              {unexpecteds.map((u, index) => <li key={index}>{u}</li>)}
+                {unexpecteds.map((u, index) => (
+                    <li key={index}>{u}</li>
+                ))}
             </ul>
         );
-
     }
 
     render() {
@@ -57,23 +68,38 @@ class TestResult extends Component {
                         </tr>
                     </thead>
                     <tbody>
-                        {testResult.result.details.commands.map((command, index) => {
-                            let passing = command.assertions.filter(a => a.pass !== undefined);
-                            let failing = command.assertions.filter(a => a.fail !== undefined);
+                        {testResult.result.details.commands.map(
+                            (command, index) => {
+                                let passing = command.assertions.filter(
+                                    a => a.pass !== undefined
+                                );
+                                let failing = command.assertions.filter(
+                                    a => a.fail !== undefined
+                                );
 
-                            return (
-                                <tr key={index}>
-                                    <td>{command.command}</td>
-                                    <td>{command.support}</td>
-                                    <td>
-                                      <p>Output: {command.output}</p>
-                                      <p>Passing Assertions:</p>{this.renderPassingAssertions(passing)}
-                                      <p>Failing Assertions:</p> {this.renderFailingAssertions(failing)}
-                                      <p>Unexpected Behaviors:</p> {this.renderUnexpected(command.unexpected_behaviors)}
-                                    </td>
-                                </tr>
-                            );
-                        })}
+                                return (
+                                    <tr key={index}>
+                                        <td>{command.command}</td>
+                                        <td>{command.support}</td>
+                                        <td>
+                                            <p>Output: {command.output}</p>
+                                            <p>Passing Assertions:</p>
+                                            {this.renderPassingAssertions(
+                                                passing
+                                            )}
+                                            <p>Failing Assertions:</p>{' '}
+                                            {this.renderFailingAssertions(
+                                                failing
+                                            )}
+                                            <p>Unexpected Behaviors:</p>{' '}
+                                            {this.renderUnexpected(
+                                                command.unexpected_behaviors
+                                            )}
+                                        </td>
+                                    </tr>
+                                );
+                            }
+                        )}
                     </tbody>
                 </Table>
             </Fragment>
@@ -82,7 +108,7 @@ class TestResult extends Component {
 }
 
 TestResult.propTypes = {
-    testReulst: PropTypes.object
+    testResult: PropTypes.object
 };
 
 export default TestResult;

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -1,54 +1,18 @@
 import React, { Component, Fragment } from 'react';
+import nextId from 'react-id-generator';
+
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
 
 class TestResult extends Component {
-    renderPassingAssertions(assertions) {
-        if (assertions.length === 0) {
-            return (
-                <ul>
-                    <li>No passing assertions.</li>
-                </ul>
-            );
+    renderOutcomeList(outcomes) {
+        if (!outcomes.length) {
+            outcomes.push('None.');
         }
         return (
             <ul>
-                {assertions.map((a, index) => (
-                    <li key={index}>{`${a.pass}: ${a.assertion}`}</li>
-                ))}
-            </ul>
-        );
-    }
-
-    renderFailingAssertions(assertions) {
-        if (assertions.length === 0) {
-            return (
-                <ul>
-                    <li>No failing assertions.</li>
-                </ul>
-            );
-        }
-        return (
-            <ul>
-                {assertions.map((a, index) => (
-                    <li key={index}>{`${a.fail}: ${a.assertion}`}</li>
-                ))}
-            </ul>
-        );
-    }
-
-    renderUnexpected(unexpecteds) {
-        if (unexpecteds.length === 0) {
-            return (
-                <ul>
-                    <li>No unexpected behavior.</li>
-                </ul>
-            );
-        }
-        return (
-            <ul>
-                {unexpecteds.map((u, index) => (
-                    <li key={index}>{u}</li>
+                {outcomes.map(outcome => (
+                    <li key={nextId()}>{outcome}</li>
                 ))}
             </ul>
         );
@@ -56,7 +20,27 @@ class TestResult extends Component {
 
     render() {
         const { testResult } = this.props;
-
+        const keys = ['pass', 'fail'];
+        const commandReports = testResult.result.details.commands.map(
+            command => {
+                let [passing, failing] = command.assertions.reduce(
+                    (accum, a) =>
+                        accum.map((assertions, index) =>
+                            assertions.concat(
+                                a[keys[index]] !== undefined
+                                    ? [`${a[keys[index]]}: ${a.assertion}`]
+                                    : []
+                            )
+                        ),
+                    [[], []]
+                );
+                return {
+                    command,
+                    passing,
+                    failing
+                };
+            }
+        );
         return (
             <Fragment>
                 <Table striped bordered hover>
@@ -68,38 +52,35 @@ class TestResult extends Component {
                         </tr>
                     </thead>
                     <tbody>
-                        {testResult.result.details.commands.map(
-                            (command, index) => {
-                                let passing = command.assertions.filter(
-                                    a => a.pass !== undefined
-                                );
-                                let failing = command.assertions.filter(
-                                    a => a.fail !== undefined
-                                );
-
-                                return (
-                                    <tr key={index}>
-                                        <td>{command.command}</td>
-                                        <td>{command.support}</td>
-                                        <td>
-                                            <p>Output: {command.output}</p>
-                                            <p>Passing Assertions:</p>
-                                            {this.renderPassingAssertions(
-                                                passing
-                                            )}
-                                            <p>Failing Assertions:</p>{' '}
-                                            {this.renderFailingAssertions(
-                                                failing
-                                            )}
-                                            <p>Unexpected Behaviors:</p>{' '}
-                                            {this.renderUnexpected(
-                                                command.unexpected_behaviors
-                                            )}
-                                        </td>
-                                    </tr>
-                                );
-                            }
-                        )}
+                        {commandReports.map(report => {
+                            const {
+                                command: {
+                                    command,
+                                    output,
+                                    support,
+                                    unexpected_behaviors
+                                },
+                                passing,
+                                failing
+                            } = report;
+                            return (
+                                <tr key={nextId()}>
+                                    <td>{command}</td>
+                                    <td>{support}</td>
+                                    <td>
+                                        <p>Output: {output}</p>
+                                        <p>Passing Assertions:</p>
+                                        {this.renderOutcomeList(passing)}
+                                        <p>Failing Assertions:</p>{' '}
+                                        {this.renderOutcomeList(failing)}
+                                        <p>Unexpected Behaviors:</p>{' '}
+                                        {this.renderOutcomeList(
+                                            unexpected_behaviors
+                                        )}
+                                    </td>
+                                </tr>
+                            );
+                        })}
                     </tbody>
                 </Table>
             </Fragment>

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -3,7 +3,7 @@
     height: 65vh;
 }
 
-.testrun__button-group--right {
+.testrun__button--right {
     position: absolute;
     right: 0;
 }

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -18,6 +18,7 @@ import {
     getTestSuiteVersions,
     saveResult
 } from '../../actions/cycles';
+import TestResult from '@components/TestResult';
 
 class TestRun extends Component {
     constructor(props) {
@@ -314,15 +315,14 @@ class TestRun extends Component {
                 } else {
                     content = (
                         <Fragment>
-                            <div>
-                                RESULTS EXIST!!!!!! TODO: Make a view of the
-                                existng tests
-                            </div>
+                            <TestResult
+                              testResult={test.result}
+                            />
                             <Button
                                 variant="primary"
                                 onClick={this.handleNextTestClick}
                             >
-                                Go to next test
+                                Next Test
                             </Button>
                         </Fragment>
                     );

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -2,15 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
-import {
-    Button,
-    ButtonGroup,
-    ButtonToolbar,
-    Col,
-    Container,
-    Modal,
-    Row
-} from 'react-bootstrap';
+import { Col, Container, Row } from 'react-bootstrap';
 import {
     getTestCycles,
     getRunsForUserAndCycle,
@@ -25,7 +17,7 @@ class TestRun extends Component {
 
         this.state = {
             currentTestIndex: 1,
-            runComplete: false,
+            runComplete: false
         };
 
         this.displayNextTest = this.displayNextTest.bind(this);
@@ -110,14 +102,10 @@ class TestRun extends Component {
         }
 
         this.testHasResults = test.result ? true : false;
-        console.log(this.testHasResults);
-
 
         let heading = null;
         let content = null;
         let testContent = null;
-        let menuUnderContent = null;
-        let menuRightOContent = null;
 
         if (testsToRun) {
             heading = (
@@ -133,17 +121,17 @@ class TestRun extends Component {
 
             if (!this.state.runComplete) {
                 testContent = (
-                        <DisplayTest
-                          test={test}
-                          testIndex={this.state.currentTestIndex}
-                          git_hash={git_hash}
-                          at_key={at_key}
-                          displayNextTest={this.displayNextTest}
-                          displayPreviousTest={this.displayPreviousTest}
-                          saveResultFromTest={this.saveResultFromTest}
-                          cycleId={cycleId}
-                        />
-                    );
+                    <DisplayTest
+                        test={test}
+                        testIndex={this.state.currentTestIndex}
+                        git_hash={git_hash}
+                        at_key={at_key}
+                        displayNextTest={this.displayNextTest}
+                        displayPreviousTest={this.displayPreviousTest}
+                        saveResultFromTest={this.saveResultFromTest}
+                        cycleId={cycleId}
+                    />
+                );
             } else {
                 content = <div>Tests are complete.</div>;
             }
@@ -167,9 +155,7 @@ class TestRun extends Component {
                         <Col>{heading}</Col>
                     </Row>
 
-                    <Row>
-                        {testContent || <Col>{content}</Col>}
-                    </Row>
+                    <Row>{testContent || <Col>{content}</Col>}</Row>
                 </Container>
             </Fragment>
         );

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "node-sass": "^4.13.1",
     "react-bootstrap": "^1.0.0",
     "react-helmet": "^6.0.0",
+    "react-id-generator": "^3.0.0",
     "sass-loader": "^8.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10959,6 +10959,11 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-id-generator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-id-generator/-/react-id-generator-3.0.0.tgz#20fba0a12355924f1d7b4bfe2ac262c0ad02c7ef"
+  integrity sha512-egmdswpzA/z8UlignCZKmJqrO0EaqmW13M8756wE+V/6NtYf0CdvDjkGpat/Q/djXfg7F/C0267Gff1RHgpfIQ==
+
 react-inspector@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-4.0.1.tgz#0f888f78ff7daccbc7be5d452b20c96dc6d5fbb8"


### PR DESCRIPTION
This PR does a lot of things because I wanted to get in some bigger changes early on Friday so that it could be code reviewed and tests. I'm sorry it's so much at once!

1. It adds a read only view of the tests
2. It simplifies the buttons, per Matts request. There is no longer a difference between "save and go to next" and "skip and go to next test". There is now just a "next test" button.
3. When editing the code to change the buttons around, the code became nightmarish, and I have a feeling this is not the "final state" of the buttons/actions on the test run page. So I did a minor refactor to break part of the page out into it's own component.

To test this PR:
- Start a test run
- Try all the buttons except for the "issue" button and the "redo test"button
- Fill in all the data for a test and click "review test" in the iframe, then try click "next or "previous", then go back to that test and see the read only view.