### PR TITLE
Tolerate login attempts from unrecognized users

### DIFF
--- a/server/services/UsersService.js
+++ b/server/services/UsersService.js
@@ -293,7 +293,7 @@ async function getUserAndUpdateRoles(options) {
 
     let newRoleList = [];
     for (let role in rolesMap) {
-        let userHasRole = dbUser.roles.includes(role);
+        let userHasRole = dbUser && dbUser.roles.includes(role);
         let userInTeam = githubUserRoles.includes(role);
 
         // User has role and is in the correct team


### PR DESCRIPTION
Because the `getUser` function may return `false`, the value of `dbUser`
should not be assumed to be an object.