### PR TITLE
Don't load environment variables with xargs for dev server

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/bocoup/aria-at-report#readme",
   "dependencies": {
     "bootstrap": "^4.4.1",
+    "dotenv-webpack": "^1.8.0",
     "node-sass": "^4.13.1",
     "react-bootstrap": "^1.0.0",
     "react-helmet": "^6.0.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
     entry: ['babel-polyfill', './index.js'],
@@ -64,6 +65,7 @@ module.exports = {
         }
     },
     plugins: [
+        new Dotenv({ path: '../config/dev.env' }),
         new CopyWebpackPlugin([
             {
                 from: 'static'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "a11y": "yarn workspace client lighthouse",
-    "dev": "export $(cat config/dev.env | xargs); npm-run-all --parallel dev:*",
+    "dev": "npm-run-all --parallel dev:*",
     "dev:client": "yarn workspace client run dev",
     "dev:server": "yarn workspace server run dev",
     "jest": "yarn workspaces run jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,6 +4882,13 @@ dotenv-webpack@^1.7.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
+dotenv-webpack@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz#7ca79cef2497dd4079d43e81e0796bc9d0f68a5e"
+  integrity sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==
+  dependencies:
+    dotenv-defaults "^1.0.2"
+
 dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"


### PR DESCRIPTION
When the variables are loaded with xargs any values with spaces in them
get split so`export $(cat config/dev.env | xargs)` produces `GITHUB_TEAM_QUERY=ARIA-AT Report GITHUB_TEAM_TESTER=ARIA-AT Report Testers GITHUB_TEAM_ADMIN=ARIA-AT Report Admin`


Which means that those env vars end up looking like:
```
process.env.GITHUB_TEAM_QUERY=ARIA-AT 
process.env.GITHUB_TEAM_TESTER=ARIA-AT
process.env.GITHUB_TEAM_ADMIN=ARIA-AT
```

This was causing the login to fail because authentication wasn't working correctly.

In the server, the environment is already loaded with `dotenv`. So we don't need to use `export` at all.

The `export` was just for the `client` now use `webpack-dotenv` for the client which is like `dotenv` but `webpack` specific. It works with the dev server and doesn't leak unused variables to the client.

https://www.npmjs.com/package/dotenv-webpack

This PR only fixes the immediately broken login in the development environment problem. But the (potential) problem with using `xargs` is in several places throughout the app:
- Importing tests in dev via the `yarn run db-import-tests:dev`
- Running anything in vagrant with the `/deploy/scripts/export-and-exec.sh` script currently used to build the frontend packages and import the tests

I'm working on a fix to switch all of these to `dotenv` so this problem doesn't creep up in other places its non-trivial to test that fix so I thought I would open this PR separately.
