### PR TITLE
Load environment in import-tests without xargs in local enviornment

### DIFF
--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -44,7 +44,7 @@
     chdir: '{{source_dir}}'
 
 - name: Import tests into database
-  command: DOTENV_CONFIG_PATH={{environment_config.dest}} node -r dotenv/config ./scripts/import-tests/index.js -c {{aria_at_test_revision}}
+  command: ./deploy/scripts/export-and-exec.sh {{environment_config.dest}} node ./server/scripts/import-tests/index.js -c {{aria_at_test_revision}}
   args:
     chdir: '{{source_dir}}'
 

--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -44,7 +44,7 @@
     chdir: '{{source_dir}}'
 
 - name: Import tests into database
-  command: ./deploy/scripts/export-and-exec.sh {{environment_config.dest}} node ./server/scripts/import-tests/index.js -c {{aria_at_test_revision}}
+  command: DOTENV_CONFIG_PATH={{environment_config.dest}} node -r dotenv/config ./scripts/import-tests/index.js -c {{aria_at_test_revision}}
   args:
     chdir: '{{source_dir}}'
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "set -e; yarn prettier; yarn lint; yarn jest; yarn workspace client lighthouse",
     "db-init:dev": "bash db/scripts/db_init.sh config/dev.env",
     "db-migrate:dev": "bash db/scripts/db_migrate.sh config/dev.env",
-    "db-import-tests:dev": "export $(cat config/dev.env | xargs); yarn workspace server import-tests",
+    "db-import-tests:dev": "yarn workspace server db-import-tests:dev",
     "storybook": "yarn workspaces run storybook"
   },
   "repository": {

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "dev": "DOTENV_CONFIG_PATH=../config/dev.env nodemon -r dotenv/config server.js --watch",
     "jest": "jest",
     "prettier": "prettier --write \"**/*.{js,jsx,css}\"",
-    "lint": "eslint --ext js,jsx ."
+    "lint": "eslint --ext js,jsx .",
+    "db-import-tests:dev": "DOTENV_CONFIG_PATH=../config/dev.env node -r dotenv/config ./scripts/import-tests/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use dotenv to load enviornment instead of xargs. Xargs is more brittle.

Also, maybe more importantly the `yarn run db-import-tests:dev` was broken since it was switched to script file. This also fixes that issue so it now can be run locally and not just for deployment.