### PR TITLE
Deployment: Do not synchronize ignored files

### DIFF
--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -12,6 +12,8 @@
   synchronize:
     src: '{{playbook_dir}}/..'
     dest: '{{source_dir}}'
+    rsync_opts:
+      - "--filter=':- .gitignore'"
   when: deployment_mode != 'development'
 
 - name: Link application code


### PR DESCRIPTION
When uploading code to a production server, skip over any files which
match the rules in the project's `.gitignore` file. This includes built
assets (which may be present on the deployer's machine and which may
describe an outdated version of the software) and Node.js dependencies
(which may include native bindings which are inappropriate for the
target system).