### PR TITLE
Accessibility fixes requested by Matt

### DIFF
--- a/client/components/App/index.jsx
+++ b/client/components/App/index.jsx
@@ -14,21 +14,47 @@ class App extends Component {
         super(props);
 
         this.signOut = this.signOut.bind(this);
+        this.currentNavItem = React.createRef();
     }
+
     async componentDidMount() {
         const { dispatch } = this.props;
 
-        await dispatch(handleCheckSignedIn());
-        await dispatch(handleGetValidAts());
-        await dispatch(getAllUsers());
+        dispatch(handleCheckSignedIn());
+        dispatch(handleGetValidAts());
+        dispatch(getAllUsers());
+    }
+
+    componentDidUpdate(prevProps) {
+        // Focus on the navigation link after updating the page
+        if (this.props.location.pathname !== prevProps.location.pathname) {
+            if (this.currentNavItem.current) {
+                this.currentNavItem.current.focus();
+            }
+        }
     }
 
     async signOut() {
-        const { dispatch } = this.props;
+        const { dispatch, location } = this.props;
         await dispatch(handleSignout());
         // Avoid the flash of "logged in user" after
         // pressing "log out"
         location.href = '/';
+    }
+
+    navProps(href) {
+        const { location } = this.props;
+
+        let navProps = {
+            to: href
+        };
+
+        if (location.pathname === href) {
+            navProps['aria-current'] = true;
+            navProps['ref'] = this.currentNavItem;
+        }
+
+        return navProps;
     }
 
     render() {
@@ -37,14 +63,16 @@ class App extends Component {
         if (!loadedUserData) {
             return null;
         }
-        const { route, isSignedIn, isAdmin, isTester } = this.props;
-        const signInURL = `${process.env.API_SERVER}/api/auth/oauth?referer=${location.origin}&service=github`;
+
+        const { route, isSignedIn, isAdmin, isTester, location } = this.props;
+        const signInURL = `${process.env.API_SERVER}/api/auth/oauth?referer=${window.location.origin}&service=github`;
+
         return (
             <Fragment>
                 <Container fluid>
                     <Navbar bg="light" expand="lg">
-                        <Navbar.Brand as={Link} to="/">
-                            <h1>ARIA-AT Report</h1>
+                        <Navbar.Brand as={Link} {...this.navProps('/')}>
+                            <h1>ARIA-AT</h1>
                         </Navbar.Brand>
                         <Navbar.Toggle aria-controls="basic-navbar-nav" />
                         <Navbar.Collapse
@@ -64,16 +92,16 @@ class App extends Component {
                             )) || (
                                 <React.Fragment>
                                     {isAdmin && (
-                                        <Nav.Link as={Link} to="/cycles">
+                                        <Nav.Link as={Link} {...this.navProps('/cycles')}>
                                             Test Management
                                         </Nav.Link>
                                     )}
                                     {isTester && (
-                                        <Nav.Link as={Link} to="/test-queue">
+                                        <Nav.Link as={Link} {...this.navProps('/test-queue')}>
                                             Test Queue
                                         </Nav.Link>
                                     )}
-                                    <Nav.Link as={Link} to="/account/settings">
+                                    <Nav.Link as={Link} {...this.navProps('/account/settings')}>
                                         Settings
                                     </Nav.Link>
                                     <Nav.Link

--- a/client/components/App/index.jsx
+++ b/client/components/App/index.jsx
@@ -35,11 +35,11 @@ class App extends Component {
     }
 
     async signOut() {
-        const { dispatch, location } = this.props;
+        const { dispatch } = this.props;
         await dispatch(handleSignout());
         // Avoid the flash of "logged in user" after
         // pressing "log out"
-        location.href = '/';
+        window.location.href = '/';
     }
 
     navProps(href) {

--- a/client/components/App/index.jsx
+++ b/client/components/App/index.jsx
@@ -64,7 +64,7 @@ class App extends Component {
             return null;
         }
 
-        const { route, isSignedIn, isAdmin, isTester, location } = this.props;
+        const { route, isSignedIn, isAdmin, isTester } = this.props;
         const signInURL = `${process.env.API_SERVER}/api/auth/oauth?referer=${window.location.origin}&service=github`;
 
         return (
@@ -92,16 +92,25 @@ class App extends Component {
                             )) || (
                                 <React.Fragment>
                                     {isAdmin && (
-                                        <Nav.Link as={Link} {...this.navProps('/cycles')}>
+                                        <Nav.Link
+                                            as={Link}
+                                            {...this.navProps('/cycles')}
+                                        >
                                             Test Management
                                         </Nav.Link>
                                     )}
                                     {isTester && (
-                                        <Nav.Link as={Link} {...this.navProps('/test-queue')}>
+                                        <Nav.Link
+                                            as={Link}
+                                            {...this.navProps('/test-queue')}
+                                        >
                                             Test Queue
                                         </Nav.Link>
                                     )}
-                                    <Nav.Link as={Link} {...this.navProps('/account/settings')}>
+                                    <Nav.Link
+                                        as={Link}
+                                        {...this.navProps('/account/settings')}
+                                    >
                                         Settings
                                     </Nav.Link>
                                     <Nav.Link

--- a/client/components/ConfigureRunsForExample/index.jsx
+++ b/client/components/ConfigureRunsForExample/index.jsx
@@ -96,7 +96,7 @@ class ConfigureRunsForExample extends Component {
         });
 
         let exampleTableTitle = example.name || example.directory;
-        let tableId = `table_name_${nextId()}`;
+        let tableId = nextId('table_name_');
 
         return (
             <Fragment>

--- a/client/components/ConfigureRunsForExample/index.jsx
+++ b/client/components/ConfigureRunsForExample/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Form, Table } from 'react-bootstrap';
+import nextId from 'react-id-generator';
 
 class ConfigureRunsForExample extends Component {
     constructor(props) {
@@ -94,11 +95,14 @@ class ConfigureRunsForExample extends Component {
             return b.at_id - a.at_id;
         });
 
+        let exampleTableTitle = example.name || example.directory;
+        let tableId = `table_name_${nextId()}`;
+
         return (
             <Fragment>
-                <h4>{example.name || example.directory}</h4>
+                <h4 id={tableId}>{exampleTableTitle}</h4>
                 {runs.length !== 0 && (
-                    <Table bordered>
+                    <Table aria-labelledby={tableId} bordered>
                         <thead>
                             <tr>
                                 <th>Assistive Technology and Browser</th>

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -79,7 +79,7 @@ class CycleSummary extends Component {
             }
         }
 
-        let tableId = `table_name_${nextId()}`;
+        let tableId = nextId('table_name_');
 
         return (
             <Fragment>

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -93,7 +93,9 @@ class CycleSummary extends Component {
                 <p>{`${
                     testSuiteVersionData.git_commit_msg
                 } - ${testSuiteVersionData.git_hash.slice(0, 8)}`}</p>
-                <h3 id={tableId} >Configured assistive technologies and browser versions</h3>
+                <h3 id={tableId}>
+                    Configured assistive technologies and browser versions
+                </h3>
                 <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
 import ConfigureRunsForExample from '@components/ConfigureRunsForExample';
+import nextId from 'react-id-generator';
 
 class CycleSummary extends Component {
     constructor(props) {
@@ -78,6 +79,8 @@ class CycleSummary extends Component {
             }
         }
 
+        let tableId = `table_name_${nextId()}`;
+
         return (
             <Fragment>
                 <Helmet>
@@ -90,8 +93,8 @@ class CycleSummary extends Component {
                 <p>{`${
                     testSuiteVersionData.git_commit_msg
                 } - ${testSuiteVersionData.git_hash.slice(0, 8)}`}</p>
-                <h3>Configured assistive technologies and browser versions</h3>
-                <Table striped bordered hover>
+                <h3 id={tableId} >Configured assistive technologies and browser versions</h3>
+                <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>
                             <th>Assisitve Technology</th>

--- a/client/components/Home/index.jsx
+++ b/client/components/Home/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 class Home extends Component {
     render() {
-        return <h1>Home Page</h1>;
+        return <h1>ARIA-AT Home</h1>;
     }
 }
 

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -19,7 +19,7 @@ class ManageCycles extends Component {
     render() {
         const { cyclesById } = this.props;
 
-        let tableId = `table_name_${nextId()}`;
+        let tableId = nextId('table_name_');
 
         return (
             <Fragment>

--- a/client/components/ManageCycles/index.jsx
+++ b/client/components/ManageCycles/index.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
 import ManageCycleRow from '@components/ManageCycleRow';
 import { getTestCycles } from '../../actions/cycles';
+import nextId from 'react-id-generator';
 
 class ManageCycles extends Component {
     componentDidMount() {
@@ -18,6 +19,8 @@ class ManageCycles extends Component {
     render() {
         const { cyclesById } = this.props;
 
+        let tableId = `table_name_${nextId()}`;
+
         return (
             <Fragment>
                 <Helmet>
@@ -27,8 +30,8 @@ class ManageCycles extends Component {
                 <Button as={Link} to="/cycles/new">
                     Initiate
                 </Button>
-                <h2>Test Cycle Status</h2>
-                <Table striped bordered hover>
+                <h2 id={tableId}>Test Cycle Status</h2>
+                <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>
                             <th>Test Cycle</th>

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { getTestCycles, getRunsForUserAndCycle } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
+import nextId from 'react-id-generator';
 
 import TestQueueRun from '@components/TestQueueRun';
 
@@ -39,10 +40,12 @@ class TestQueue extends Component {
             browser_version: browserVersion
         } = cycle.runsById[runIds[0]];
 
+        let tableId = `table_name_${nextId()}`;
+
         return (
             <div key={`${atName}${browserName}`}>
-                <h3>{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h3>
-                <Table striped bordered hover>
+                <h3 id={tableId}>{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h3>
+                <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>
                             <th>Test Plan</th>

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -44,7 +44,9 @@ class TestQueue extends Component {
 
         return (
             <div key={`${atName}${browserName}`}>
-                <h3 id={tableId}>{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h3>
+                <h3
+                    id={tableId}
+                >{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h3>
                 <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -40,7 +40,7 @@ class TestQueue extends Component {
             browser_version: browserVersion
         } = cycle.runsById[runIds[0]];
 
-        let tableId = `table_name_${nextId()}`;
+        let tableId = nextId('table_name_');
 
         return (
             <div key={`${atName}${browserName}`}>

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -80,13 +80,13 @@ class TestQueueRow extends Component {
             .map(uid => (
                 <div
                     key={nextId()}
-                >{`${usersById[uid].fullname} 0/${totalTests} complete`}</div>
+                >{`${usersById[uid].fullname} 0 of ${totalTests} tests complete`}</div>
             ));
         if (currentUserAssigned) {
             userInfo.unshift(
                 <div
                     key={nextId()}
-                >{`${usersById[userId].fullname} ${testsCompleted}/${totalTests} complete `}</div>
+                >{`${usersById[userId].fullname} ${testsCompleted} of ${totalTests} tests complete `}</div>
             );
         }
 

--- a/client/components/TesterHome/index.jsx
+++ b/client/components/TesterHome/index.jsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Button, Table } from 'react-bootstrap';
 import { getTestCycles } from '../../actions/cycles';
+import nextId from 'react-id-generator';
 
 class TesterHome extends Component {
     componentDidMount() {
@@ -16,13 +17,16 @@ class TesterHome extends Component {
 
     render() {
         const { cyclesById } = this.props;
+
+        let tableId = `table_name_${nextId()}`;
+
         return (
             <Fragment>
                 <Helmet>
                     <title>Test Queue (for all cycles) | ARIA-AT</title>
                 </Helmet>
-                <h2>Test Cycles</h2>
-                <Table striped bordered hover>
+                <h2 id={tableId}>Test Cycles</h2>
+                <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>
                             <th>Test Cycle</th>

--- a/client/components/TesterHome/index.jsx
+++ b/client/components/TesterHome/index.jsx
@@ -18,7 +18,7 @@ class TesterHome extends Component {
     render() {
         const { cyclesById } = this.props;
 
-        let tableId = `table_name_${nextId()}`;
+        let tableId = nextId('table_name_');
 
         return (
             <Fragment>


### PR DESCRIPTION
This does three things:
1. The nav link for the current page now has `aria-current="page"` set, and when you click a click, the focus is put on the nav item so the SR user hears the `aria-current` change. This is to better handle the "single-paged-ness" of the app.
2. All the tables have accessible names
3. A confusing phrase updated to be more wordy