### PR TITLE
Add flexibility to import script

### DIFF
--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -150,6 +150,7 @@ const ariaat = {
                         );
 
                         let appliesToList = [];
+
                         for (let a of testData.applies_to) {
                             if (support.applies_to[a]) {
                                 appliesToList = appliesToList.concat(
@@ -160,8 +161,10 @@ const ariaat = {
                             }
                         }
 
+                        // There is a bug in the test where sometimes "key" is used in the applies to list,
+                        // and sometimes the "name"
                         for (let name of appliesToList) {
-                            const at = support.ats.find(a => a.name === name);
+                            const at = support.ats.find(a => { return a.name === name || a.key === name; });
                             if (at) {
                                 await this.upsertTestToAt(testID, at.atID);
                             }

--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -150,7 +150,6 @@ const ariaat = {
                         );
 
                         let appliesToList = [];
-
                         for (let a of testData.applies_to) {
                             if (support.applies_to[a]) {
                                 appliesToList = appliesToList.concat(
@@ -164,7 +163,7 @@ const ariaat = {
                         // There is a bug in the test where sometimes "key" is used in the applies to list,
                         // and sometimes the "name"
                         for (let name of appliesToList) {
-                            const at = support.ats.find(a => { return a.name === name || a.key === name; });
+                            const at = support.ats.find(a => ( a.name === name || a.key === name ));
                             if (at) {
                                 await this.upsertTestToAt(testID, at.atID);
                             }


### PR DESCRIPTION
There has been a change upstream in "aria-at" where the "applies_to" list in the script may contain the "key" that refers to a screen reader, instead of the screen readers "name" (this information is in the [support.json](https://github.com/w3c/aria-at/blob/master/tests/support.json) file -- every AT has a human readable name and a machine readable key). The "applies_to" list tells you if the test applies to all screen readers or a subset of screen readers.

Rather than wait for a conclusion on which to use (name or key?) from the upstream, I made the script flexible -- if you use name or key, it will know what you mean.

To test, do the following:

```
// Run from the aria-at-repo repository
yarn db-import-tests:dev -c 0a88a6ceae079db866c561fbac26576519cca2f9

// Run from the aria-at-tests directory
git clone git@github.com:w3c/aria-at.git 0a88a6ceae079db866c561fbac26576519cca2f9
cd 0a88a6ceae079db866c561fbac26576519cca2f9
git reset --hard 0a88a6ceae079db866c561fbac26576519cca2f9
```

The `yarn dev` and go to localhost:3000, initiate a test cycle with THREE run configurations, one for VoiceOver, JAWS and NVDA. Assign yourself to all of them. Try running all tests. There will be less tests for every VoiceOver run for all design patterns.