### PR TITLE
Add `yarn run dev-debug` to improve debugging experience

### DIFF
--- a/docs/Local Development.md
+++ b/docs/Local Development.md
@@ -32,6 +32,19 @@ yarn dev  // Runs dev server
 
 Now you can navigate your browser to: http://0.0.0.0:3000/
 
+### Debugging
+
+Instead of running `yarn dev` to start the local enviornment run `yarn run dev-debug`.
+
+This will add [express debuging](https://expressjs.com/en/guide/debugging.html)
+to information about routes, middleware and the request responce cycle.
+
+Additionally it adds the the ability for you use chrome dev tools and a
+`debbuger` to step through code via node's build in
+[inspector](https://nodejs.org/en/docs/guides/debugging-getting-started/). Just
+navigate to (chrome://inspect/#devices)[chrome://inspect/#devices] and open the
+dedicated dev tools for node.
+
 ## Sandboxing UI Components with Storybook
 Client side React UI components can be prototyped on [Storybook](https://storybook.js.org/). Storybook is a tool that allows developers to create components outside of the overall application system.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev": "npm-run-all --parallel dev:*",
     "dev:client": "yarn workspace client run dev",
     "dev:server": "yarn workspace server run dev",
+    "dev-debug": "npm-run-all --parallel dev:client dev-debug:server",
+    "dev-debug:server": "yarn workspace server run dev-debug",
     "jest": "yarn workspaces run jest",
     "prettier": "yarn workspaces run prettier",
     "lint": "yarn workspaces run lint",

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "DOTENV_CONFIG_PATH=../config/dev.env nodemon -r dotenv/config server.js --watch",
+    "dev-debug": "DEBUG=express:* DOTENV_CONFIG_PATH=../config/dev.env nodemon --inspect -r dotenv/config server.js --watch",
     "jest": "jest",
     "prettier": "prettier --write \"**/*.{js,jsx,css}\"",
     "lint": "eslint --ext js,jsx .",


### PR DESCRIPTION
See the updated Local Development docs for an explanation of the added
power that this command gives you.

You can see it in use here: More express logging on the left and the node debugger on the right.
![Screenshot from 2020-05-14 10-39-14](https://user-images.githubusercontent.com/352375/81968348-23d3ad80-95d1-11ea-92ad-3094442f4ed3.png)


I added another runner because the new logging could add a bunch of noise
other people don't like but really it could just be added to the
existing runner if people prefer.

I additionally looked into adding something like `express-winston` for
logging that could be used not just in for debugging but I just went
the route of just using the node debugger for now because for local dev
use it is faster to set up and provides about equivalent information.