### PR TITLE
fixing gitignore filter ansible

### DIFF
--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -13,7 +13,7 @@
     src: '{{playbook_dir}}/..'
     dest: '{{source_dir}}'
     rsync_opts:
-      - "--filter=':- .gitignore'"
+      - '--filter=:- .gitignore'
   when: deployment_mode != 'development'
 
 - name: Link application code


### PR DESCRIPTION
**UPDATE: the problem faced below is no longer an issue with the latest change.**

Staging deployment was not working for me. In order to fix it, I had to make this change and run `git clean -fdx`. See the errors below:

* **mac**:
TASK [application : Upload project source code] ****************************************************************************
fatal: [ara.w3.org]: FAILED! => {"changed": false, "cmd": "/usr/local/bin/rsync --delay-updates -F --compress --archive --rsh=/usr/bin/ssh -S none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null --filter=':- .gitignore' --out-format=<<CHANGED>>%i %n%L /Users/evmiguel/repos/bocoup/aria-at-report/deploy/.. root@ara.w3.org:/home/aria-bot/aria-at-report", "msg": "Unknown filter rule: `':- .gitignore''\nrsync error: syntax or usage error (code 1) at exclude.c(927) [client=3.1.3]\n", "rc": 1}

* **ubuntu**
TASK [application : Upload project source code] **************************************************************************************************************************************
fatal: [ara.w3.org]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh=/usr/bin/ssh -S none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null --filter=':- .gitignore' --out-format=<<CHANGED>>%i %n%L /home/erika/aria-at-report/deploy/.. root@ara.w3.org:/home/aria-bot/aria-at-report", "msg": "Unknown filter rule: `':- .gitignore''\nrsync error: syntax or usage error (code 1) at exclude.c(927) [client=3.1.3]\n", "rc": 1}
PLAY RECAP ***************************************************************************************************************************************************************************
ara.w3.org                 : ok=14   changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0   