### PR TITLE
Do not send 'user_to_at.active' to frontend

### DIFF
--- a/client/components/ConfigureRunsForExample/index.jsx
+++ b/client/components/ConfigureRunsForExample/index.jsx
@@ -61,9 +61,9 @@ class ConfigureRunsForExample extends Component {
 
                 // Make sure the user can be assigned to this run
                 runId = parseInt(runId);
-                const atName = runs.find(r => r.id === runId).at_name;
+                const atNameId = runs.find(r => r.id === runId).at_name_id;
                 const userAts = usersById[value].configured_ats;
-                if (userAts.find(ua => ua.at_name === atName && ua.active)) {
+                if (userAts.find(ua => ua.at_name_id === atNameId)) {
                     runIds.push(runId);
                 }
             }

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -246,9 +246,11 @@ class InitiateCycle extends Component {
                     continue;
                 }
 
-                let at_name = versionData.supported_ats.find(at => {
-                    return row.at_id === at.at_id;
-                }).at_name;
+                let { at_name, at_name_id } = versionData.supported_ats.find(
+                    at => {
+                        return row.at_id === at.at_id;
+                    }
+                );
 
                 let browser_name = versionData.browsers.find(b => {
                     return row.browser_id === b.id;
@@ -257,6 +259,7 @@ class InitiateCycle extends Component {
                 runs.push({
                     id: i,
                     at_name: at_name,
+                    at_name_id: at_name_id,
                     browser_name: browser_name,
                     at_id: row.at_id,
                     browser_id: row.browser_id

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -91,17 +91,17 @@ class TestQueue extends Component {
         }
 
         let currentUser = usersById[userId];
-        let configuredAtNames = currentUser.configured_ats
-            .filter(a => a.active)
-            .map(a => a.at_name);
+        let configuredAtNameIds = currentUser.configured_ats.map(
+            a => a.at_name_id
+        );
 
         let atBrowserRunSets = [];
         if (cycle) {
             for (let runId in cycle.runsById) {
                 const run = cycle.runsById[runId];
-                const { at_name, browser_name } = run;
+                const { at_name_id, at_name, browser_name } = run;
 
-                if (!configuredAtNames.includes(at_name)) {
+                if (!configuredAtNameIds.includes(at_name_id)) {
                     continue;
                 }
 

--- a/client/components/UserSettings/index.jsx
+++ b/client/components/UserSettings/index.jsx
@@ -30,10 +30,7 @@ class UserSettings extends Component {
                         return [
                             at.name,
                             {
-                                checked:
-                                    userAt.length > 0
-                                        ? userAt.pop().active
-                                        : false
+                                checked: userAt.length ? true : false
                             }
                         ];
                     })

--- a/client/reducers/users.js
+++ b/client/reducers/users.js
@@ -19,22 +19,9 @@ export default (state = initialState, action) => {
         }
         case SET_USER_ATS: {
             let { userId, ats } = action.payload;
-            let updateUser = { ...state.usersById[userId] };
-            let configuredUserAts = updateUser.configured_ats;
 
-            let updatedAts = [];
-            for (let at of ats) {
-                let atFound = configuredUserAts.find(
-                    configuredAt => configuredAt.at_name_id === at.at_name_id
-                );
-                if (atFound) {
-                    atFound.active = at.active;
-                    updatedAts.push(atFound);
-                } else {
-                    updatedAts.push(at);
-                }
-            }
-            updateUser.configured_ats = updatedAts;
+            let updateUser = { ...state.usersById[userId] };
+            updateUser.configured_ats = ats;
 
             return {
                 ...state,

--- a/client/tests/integration.test.js
+++ b/client/tests/integration.test.js
@@ -149,12 +149,10 @@ describe('users action dispatchers', () => {
                         username: 'foobar',
                         configured_ats: [
                             {
-                                at_name_id: 1,
-                                active: false
+                                at_name_id: 1
                             },
                             {
-                                at_name_id: 2,
-                                active: true
+                                at_name_id: 2
                             }
                         ]
                     }
@@ -192,12 +190,10 @@ describe('users action dispatchers', () => {
                 status: 200,
                 response: [
                     {
-                        at_name_id: 1,
-                        active: false
+                        at_name_id: 1
                     },
                     {
-                        at_name_id: 2,
-                        active: true
+                        at_name_id: 2
                     }
                 ]
             });

--- a/server/models/AtName.js
+++ b/server/models/AtName.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    let AtName = sequelize.define(
         'AtName',
         {
             id: {
@@ -19,4 +19,6 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'at_name'
         }
     );
+
+    return AtName;
 };

--- a/server/models/UserToAt.js
+++ b/server/models/UserToAt.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    let UserToAt = sequelize.define(
         'UserToAt',
         {
             id: {
@@ -35,4 +35,17 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'user_to_at'
         }
     );
+
+    UserToAt.associate = function(models) {
+        models.UserToAt.belongsTo(models.Users, {
+            foreignKey: 'user_id',
+            targetKey: 'id'
+        });
+        models.UserToAt.belongsTo(models.AtName, {
+            foreignKey: 'at_name_id',
+            targetKey: 'id'
+        });
+    };
+
+    return UserToAt;
 };

--- a/server/models/Users.js
+++ b/server/models/Users.js
@@ -42,6 +42,5 @@ module.exports = function(sequelize, DataTypes) {
             }
         });
     };
-
     return Users;
 };

--- a/server/models/__mocks__/index.js
+++ b/server/models/__mocks__/index.js
@@ -1,5 +1,4 @@
 const create = require('../../tests/util/create');
-const listOfAts = require('../../tests/mock-data/listOfATs.json');
 const users = require('../../tests/mock-data/users.json');
 const atsData = require('../../tests/mock-data/listOfATs.json');
 const db = {};
@@ -38,7 +37,11 @@ db.Role = {
 
 db.UserToAt = {
     findAll() {
-        return listOfAts.atsDB;
+        return [
+            {
+                dataValues: { at_name_id: 1 }
+            }
+        ];
     }
 };
 

--- a/server/services/__mocks__/UsersService.js
+++ b/server/services/__mocks__/UsersService.js
@@ -17,9 +17,7 @@ const UsersService = {
         return [
             {
                 ...users[0],
-                configured_ats: [
-                    { active: true, at_name: 'Foo', at_name_id: 1 }
-                ]
+                configured_ats: [{ at_name_id: 1 }]
             }
         ];
     }

--- a/server/tests/unit/services.test.js
+++ b/server/tests/unit/services.test.js
@@ -58,9 +58,7 @@ describe('UsersService', () => {
             const testers = await UsersService.getAllTesters();
             expect(testers[0]).toEqual({
                 ...users[0],
-                configured_ats: [
-                    { active: true, at_name: 'Foo', at_name_id: 1 }
-                ]
+                configured_ats: [{ at_name_id: 1 }]
             });
         });
     });


### PR DESCRIPTION
There was a lot of confusing logic related configured ats -- if you didn't have an AT configured, it might not show up in your list OR it will show up in your list with `at.active = false`.

This change makes the "active" field in a "UserToAt" record is a back end only concept, which only changes how to you save the records to the database. For the front end, users have a list containing only the ats they have configured.

It was a little spidery to entangle and test but I hope it made things easier to reason about going forward XD