### PR TITLE
Test queue -- admin view + assign users

### DIFF
--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import nextId from 'react-id-generator';
-import { Button } from 'react-bootstrap';
+import { Button, Dropdown } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { deleteUsersFromRun, saveUsersToRuns } from '../../actions/cycles';
@@ -9,18 +9,42 @@ import { deleteUsersFromRun, saveUsersToRuns } from '../../actions/cycles';
 class TestQueueRow extends Component {
     constructor(props) {
         super(props);
-        this.handleUnassignClick = this.handleUnassignClick.bind(this);
-        this.handleAssignClick = this.handleAssignClick.bind(this);
+
+        this.handleUnassignSelfClick = this.handleUnassignSelfClick.bind(this);
+        this.handleAssignSelfClick = this.handleAssignSelfClick.bind(this);
+        this.assignTesterSelect = this.assignTesterSelect.bind(this);
+        this.unassignTesterSelect = this.unassignTesterSelect.bind(this);
+
+        this.testerList = React.createRef();
     }
 
-    handleUnassignClick() {
+    handleUnassignSelfClick() {
         const { dispatch, cycleId, userId, runId } = this.props;
         dispatch(deleteUsersFromRun([userId], runId, cycleId));
     }
 
-    handleAssignClick() {
+    handleAssignSelfClick() {
         const { dispatch, cycleId, userId, runId } = this.props;
         dispatch(saveUsersToRuns([userId], [runId], cycleId));
+    }
+
+    assignTesterSelect(event) {
+        const { dispatch, cycleId, runId } = this.props;
+        let uid = parseInt(event.target.value);
+        dispatch(saveUsersToRuns([uid], [runId], cycleId));
+    }
+
+    unassignTesterSelect(event) {
+        const { dispatch, cycleId, runId } = this.props;
+        let uid = parseInt(event.target.value);
+        dispatch(deleteUsersFromRun([uid], runId, cycleId));
+    }
+
+    componentDidUpdate(prevProps) {
+        // Focus on the user list after editing the user list
+        if (this.props.testers.length !== prevProps.testers.length) {
+            this.testerList.current.focus();
+        }
     }
 
     renderTestsCompletedByUser(uid) {
@@ -35,21 +59,136 @@ class TestQueueRow extends Component {
         ).length;
 
         return (
-            <div
+            <li
                 key={nextId()}
-            >{`${usersById[uid].username} ${testsCompleted} of ${totalTests} tests complete`}</div>
+            >{`${usersById[uid].username} ${testsCompleted} of ${totalTests} tests complete`}</li>
         );
+    }
+
+    renderAssignDropdowns() {
+        const {
+            apgExampleName,
+            atName,
+            atNameId,
+            browserName,
+            testers,
+            usersById
+        } = this.props;
+
+        let testrun = `${apgExampleName} for ${atName} on ${browserName}`;
+
+        let canUnassignTesters = [];
+        let canAssignTesters = [];
+        for (let uid of Object.keys(usersById)) {
+            const tester = usersById[uid];
+
+            if (testers.includes(tester.id)) {
+                canUnassignTesters.push(tester);
+            } else if (
+                tester.configured_ats.find(ua => ua.at_name_id === atNameId)
+            ) {
+                canAssignTesters.push(tester);
+            }
+        }
+        return (
+            <Fragment>
+                <Dropdown>
+                    <Dropdown.Toggle
+                        id={nextId()}
+                        aria-label={`Assign Testers to ${testrun}`}
+                        disabled={canAssignTesters.length ? false : true}
+                    >
+                        Assign Testers
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                        {canAssignTesters.map(t => {
+                            return (
+                                <Dropdown.Item
+                                    as="button"
+                                    key={nextId()}
+                                    value={t.id}
+                                    onClick={this.assignTesterSelect}
+                                >
+                                    {t.username}
+                                </Dropdown.Item>
+                            );
+                        })}
+                    </Dropdown.Menu>
+                </Dropdown>
+                <Dropdown>
+                    <Dropdown.Toggle
+                        id={nextId()}
+                        aria-label={`Unassign Testers from ${testrun}`}
+                        disabled={canUnassignTesters.length ? false : true}
+                    >
+                        Unassign Testers
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                        {canUnassignTesters.map(t => {
+                            return (
+                                <Dropdown.Item
+                                    as="button"
+                                    key={nextId()}
+                                    value={t.id}
+                                    onClick={this.unassignTesterSelect}
+                                >
+                                    {t.username}
+                                </Dropdown.Item>
+                            );
+                        })}
+                    </Dropdown.Menu>
+                </Dropdown>
+            </Fragment>
+        );
+    }
+
+    renderAssignSelfButton(currentUserAssigned) {
+        const { apgExampleName, atName, browserName } = this.props;
+
+        let testrun = `${apgExampleName} for ${atName} on ${browserName}`;
+
+        if (currentUserAssigned) {
+            return (
+                <Button
+                    onClick={this.handleUnassignSelfClick}
+                    aria-label={`Unassign me from the test run ${testrun}`}
+                >
+                    Unassign Me
+                </Button>
+            );
+        } else {
+            return (
+                <Button
+                    onClick={this.handleAssignSelfClick}
+                    aria-label={`Assign me to the test run ${testrun}`}
+                >
+                    Assign Me
+                </Button>
+            );
+        }
+    }
+
+    renderTesterList(currentUserAssigned) {
+        const { testers, userId } = this.props;
+
+        let userInfo = testers
+            .filter(uid => uid !== userId)
+            .map(uid => this.renderTestsCompletedByUser(uid));
+        if (currentUserAssigned) {
+            userInfo.unshift(this.renderTestsCompletedByUser(userId));
+        }
+
+        return userInfo;
     }
 
     render() {
         const {
+            admin,
             cycleId,
             userId,
             runId,
             testers,
-            apgExampleName,
-            atName,
-            browserName
+            apgExampleName
         } = this.props;
         let currentUserAssigned = testers.includes(userId);
 
@@ -64,38 +203,16 @@ class TestQueueRow extends Component {
             designPatternLinkOrName = apgExampleName;
         }
 
-        let testrun = `${apgExampleName} for ${atName} on ${browserName}`;
-        let assignOrUnassignButton;
-        if (currentUserAssigned) {
-            assignOrUnassignButton = (
-                <Button
-                    onClick={this.handleUnassignClick}
-                    aria-label={`Unassign me from the test run ${testrun}`}
-                >
-                    Unassign Me
-                </Button>
-            );
-        } else if (testers.length < 2) {
-            assignOrUnassignButton = (
-                <Button
-                    onClick={this.handleAssignClick}
-                    aria-label={`Assign me to the test run ${testrun}`}
-                >
-                    Assign Me
-                </Button>
-            );
+        let assignOptions;
+        if (admin) {
+            assignOptions = this.renderAssignDropdowns();
+        } else {
+            assignOptions = this.renderAssignSelfButton(currentUserAssigned);
         }
 
-        let userInfo = testers
-            .filter(uid => uid !== userId)
-            .map(uid => this.renderTestsCompletedByUser(uid));
-
-        if (currentUserAssigned) {
-            userInfo.unshift(this.renderTestsCompletedByUser(userId));
-        }
-
+        let testerList = this.renderTesterList(currentUserAssigned);
         let status = 'Not started';
-        if (userInfo.length) {
+        if (testerList.length) {
             status = 'In Progress';
         }
 
@@ -103,16 +220,23 @@ class TestQueueRow extends Component {
             <tr key={runId}>
                 <td>{designPatternLinkOrName}</td>
                 <td>
-                    {userInfo.length !== 0 ? userInfo : 'No testers assigned'}
+                    <ul tabIndex="-1" ref={this.testerList}>
+                        {testerList.length !== 0 ? (
+                            testerList
+                        ) : (
+                            <li>No testers assigned</li>
+                        )}
+                    </ul>
                 </td>
                 <td>{status}</td>
-                <td>{assignOrUnassignButton}</td>
+                <td>{assignOptions}</td>
             </tr>
         );
     }
 }
 
 TestQueueRow.propTypes = {
+    admin: PropTypes.bool,
     cycleId: PropTypes.number,
     runId: PropTypes.number,
     apgExampleName: PropTypes.string,
@@ -120,6 +244,7 @@ TestQueueRow.propTypes = {
     usersById: PropTypes.object,
     userId: PropTypes.number,
     atName: PropTypes.string,
+    atNameId: PropTypes.atNameId,
     browserName: PropTypes.string,
     dispatch: PropTypes.func,
     testsForRun: PropTypes.array


### PR DESCRIPTION
To test this PR, you probably will want to add another user to the database. You can add a user like this:
```
insert into users (username) values ('foobar');
insert into user_to_at (user_id, at_name_id, active) values (${userID}, 1, true);
```

Before testing, you will also want to make sure not all AT's are selected in your user settings and to initiate a cycle with runs for all possible ATs.

Now, first, make sure you are NOT a in the [admin group](https://github.com/orgs/bocoup/teams/aria-at-report-admin/members), and log out and back in again:
- Navigate to the cycle by navigating to the "test queue" page and clicking "contribute tests" for that cycle.
- You should only see the runs you can contribute to.
- You should be able to assign and unassign yourself to all runs
- Focus should move to the list of users after you assign/unassign yourself

Now, make it so that you ARE in the admin group:
- Navigate to the cycle by navigating to the "test queue" page and clicking "contribute tests" for that cycle.
- You should see all runs!!
- You should be able to assign and unassign users to runs, based on their user preferences
- If you can assign or unassign no more users to run, the drop down button should be disabled
- Focus should move to the list of users after you assign/unassign users