### PR TITLE
Infrastructure for serving ARIA-AT Report on GitHub Pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 module.exports = function(eleventyConfig) {
   let tableify = require("tableify");
+  const pathPrefix = '/aria-at-report'; // This is for deployment to GitHub pages
 
   eleventyConfig.addShortcode("resultsTable", function(value, testPageName) {
     const table = [];
@@ -42,7 +43,7 @@ module.exports = function(eleventyConfig) {
     }
     let rv = tableify(table);
     if (!testPageName) {
-      rv = rv.replace(/<tr><td class="string">([^<]+)/g, '<tr><td class="string"><a href="/results/$1">$1</a>');
+      rv = rv.replace(/<tr><td class="string">([^<]+)/g, `<tr><td class="string"><a href="${ pathPrefix }/results/$1">$1</a>`);
     } else {
     	rv = rv.replace(/<\/td><td class="string">([^<]+)/g, '</td><td class="string"><pre>$1</pre>');
     }
@@ -53,6 +54,7 @@ module.exports = function(eleventyConfig) {
 
   return {
     passthroughFileCopy: true,
+    pathPrefix,
   	dir: {
   		input: "pages",
   		output: "_site",

--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -1,0 +1,27 @@
+name: Eleventy Build
+
+on:
+  push:
+    branches:
+      - main
+      
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v2
+
+        - name: Setup Node
+          uses: actions/setup-node@v1
+          with:
+            node-version: '10.x'
+
+        - run: npm ci
+
+        - run: npm run build
+
+        - name: Deploy
+          uses: peaceiris/actions-gh-pages@v3
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: ./_site

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # aria-at-report
+
+# Local Development
+1. Build the site with Eleventy using `npm run build`.
+2. Serve the site locally with `npm run serve`.
+
+# Deploying to GitHub Pages
+Currently, changes to any branch will cause a deploy to GitHub pages automatically.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "eleventy",
+    "serve": "eleventy --serve"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR contains the changes for ARIA-AT Report to be served on GitHub Pages. Here are some issues that might be controversial:

- Because the GitHub pages URL is **https://bocoup.github.io/aria-at-report/**, I needed to add a pathPrefix to deploy to the /aria-at-report subdirectory. Locally, this means navigating to localhost:8080/aria-at-report for the page to work. Netlify previews are broken when looking for results.
- The good news is that we can remove the pathPrefix when we have a domain name.
- On https://bocoup.github.io/aria-at-report/, the alert test and vertical-temperature-slider tests are out of place. Alert should be first and vertical-temperature-slider should be last. This only happens when the site is built in the GitHub action. Is this something that should be fixed?